### PR TITLE
Added SSL and XMLRENDERER alias

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,3 +1,5 @@
 %KERNEL_HEADERS:kernel-headers kernel-headers-2.6
 %KMOD:kmod module-init-tools
+%SSL:openssl gnutls
 %UDEV:systemd udev
+%XMLRENDERER:libxml2 expat


### PR DESCRIPTION
openssl of the SSL alias is in core.
libxml2 and expat of the XMLRENDERER alias are in core.

These should be removed from the current alias file too.
