### PR TITLE
glib-2: Removed python as an hard dependency

### DIFF
--- a/libs/glib-2/BUILD
+++ b/libs/glib-2/BUILD
@@ -2,12 +2,23 @@
 
   # Do not remove --enable-debug=minimum, it will break some common
   # API functions if debug is entirely disabled
-  export OPTS+=" --disable-static --enable-shared --enable-debug=minimum"  &&
+  export OPTS+=" --disable-static --enable-shared --enable-debug=minimum --disable-fam"  &&
 
-  if [ "`get_module_config DOCS`" = "n" ] ; then
-    sedit "s/SUBDIRS = . m4macros glib gmodule gthread gobject gio tests po docs/SUBDIRS = . m4macros glib gmodule gthread gobject gio tests po/g" Makefile.in
+  if [ "$DOCS" = "n" ] || ! in_depends $MODULE Python; then
+    sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.in
+    sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.am
   fi  &&
 
+  # Don't build tests if we don't have python
+  # Tests are required if docs are built
+  if ! in_depends $MODULE Python && [ "$DOCS" = "n" ]; then
+    for i in $(find . -name Makefile.in -o -name Makefile.am); do
+      sedit "s;^\(.*\SUBDIRS .*\=.*\)tests\(.*\)$;\1\2;" $i
+    done
+  fi &&
+
+  patch_it $SOURCE2 1 &&
+  AT_M4DIR=. autoreconf && 
   default_build
 
 ) > $C_FIFO 2>&1

--- a/libs/glib-2/DEPENDS
+++ b/libs/glib-2/DEPENDS
@@ -1,3 +1,3 @@
-depends  zlib
-depends  libffi
-depends  Python
+depends zlib
+depends libffi
+optional_depends Python "" "" "build tests (for docs also say yes here)?"

--- a/libs/glib-2/DETAILS
+++ b/libs/glib-2/DETAILS
@@ -1,13 +1,16 @@
           MODULE=glib-2
          VERSION=32.3
           SOURCE=$MODULE.$VERSION.tar.xz
+	 SOURCE2=glib-2.31.x-external-gdbus-codegen.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE.$VERSION
    SOURCE_URL[0]=$GNOME_URL/sources/glib/${MODULE#*-}.${VERSION%.*}
    SOURCE_URL[1]=ftp://ftp.gtk.org/pub/glib/${MODULE#*-}.${VERSION%.*}
+     SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha1:429355327aaf69d2c21cbefcb20c61db94e0acec
+     SOURCE2_VFY=sha1:6625bbb01a5b39970a28f78503bcc58e13cd5297
         WEB_SITE=http://library.gnome.org/devel/glib
          ENTERED=20020313
-         UPDATED=20120515
+         UPDATED=20120711
            SHORT="A library of useful C routines for trees, hashes, and lists"
 
 cat << EOF


### PR DESCRIPTION
Python is no longer a required dependency for glib-2. gdbus-codegen
has been broken out into it's own module named gdbus-codegen. This
change will allow us to drop Python from core modules.

NOTE!
gdbus-codegen will be committed to other if this change is accepted.
