### PR TITLE
glib-2: Removing docs option completely for now

### DIFF
--- a/libs/glib-2/BUILD
+++ b/libs/glib-2/BUILD
@@ -4,20 +4,19 @@
   # API functions if debug is entirely disabled
   export OPTS+=" --disable-static --enable-shared --enable-debug=minimum --disable-fam"  &&
 
-  if [ "$DOCS" = "n" ] || ! in_depends $MODULE Python; then
-    sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.in
-    sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.am
-  fi  &&
+  # Disable docs (require Python and gdbus-codegen), we can enable
+  # this later if necessary by introducing a glib-2-docs module
+  sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.in
+  sedit "s;^\(.*\SUBDIRS .*\=.*\)docs\(.*\)$;\1\2;" Makefile.am
 
-  # Don't build tests if we don't have python
-  # Tests are required if docs are built
-  if ! in_depends $MODULE Python && [ "$DOCS" = "n" ]; then
-    for i in $(find . -name Makefile.in -o -name Makefile.am); do
-      sedit "s;^\(.*\SUBDIRS .*\=.*\)tests\(.*\)$;\1\2;" $i
-    done
-  fi &&
-
+  # Don't build tests
+  for i in $(find . -name Makefile.in -o -name Makefile.am); do
+    sedit "s;^\(.*\SUBDIRS .*\=.*\)tests\(.*\)$;\1\2;" $i
+  done
+  
+  # This patch splits out gdbus-codegen which is a separate module now
   patch_it $SOURCE2 1 &&
+
   AT_M4DIR=. autoreconf && 
   default_build
 

--- a/libs/glib-2/CONFIGURE
+++ b/libs/glib-2/CONFIGURE
@@ -1,1 +1,0 @@
-mquery DOCS "Build docs?" n

--- a/libs/glib-2/DEPENDS
+++ b/libs/glib-2/DEPENDS
@@ -1,3 +1,2 @@
 depends zlib
 depends libffi
-optional_depends Python "" "" "build tests (for docs also say yes here)?"


### PR DESCRIPTION
Due to the complexity of multiple modules needed for docs and tests
I decided to disable docs for the moment. Docs require Python and
gdbus-codegen that we split out. One reason why I decided to disable
it was that in one case this would have created a circular depdendency.

If docs are wanted later we just introduce a glib-2-docs module that
will have Python and gdbus-codegen as hard dependencies and add that
module as optional to glib-2.
