### PR TITLE
kernel: Stop kernel from installing conflicting firmware

### DIFF
--- a/kernel/linux/BUILD
+++ b/kernel/linux/BUILD
@@ -1,5 +1,8 @@
 (
 
+  # Do not install firmware on modules_install
+  sedit '/Makefile.*__fw_modinst/d' Makefile
+
 # Needed for x86_64
   MYARCH="`arch | grep -qw i.86 && echo i386 || arch`"
 

--- a/kernel/linux/DEPENDS
+++ b/kernel/linux/DEPENDS
@@ -1,2 +1,3 @@
 depends  autoconf
 depends  %KMOD
+depends  linux-firmware


### PR DESCRIPTION
This patch take care of stopping the kernel from installing conflicting firmware files with linux-firmware.
linux-firmware was also added as a dependency to the kernel.
