### PR TITLE
systemd: Generate an os-release file that is shell-compatible

### DIFF
--- a/system/systemd/BUILD
+++ b/system/systemd/BUILD
@@ -17,11 +17,6 @@
   # vconsole.conf defaults to us-layout
   [ -f /etc/vconsole.conf ] || install -m 0644 -o root -g root $SCRIPT_DIRECTORY/files/vconsole.conf /etc/vconsole.conf &&
 
-  # os-release should properly show lunar
-  # todo: we might replace this with some auto-generated
-  #       values from /etc/lunar.release in the future.
-  [ -f /etc/os-release ] || install -m 0644 -o root -g root $SCRIPT_DIRECTORY/files/os-release /etc/os-release &&
-
   # last but not least the locale settings, defaulting to US
   [ -f /etc/locale.conf ] || install -m 0644 -o root -g root $SCRIPT_DIRECTORY/files/locale.conf /etc/locale.conf &&
 

--- a/system/systemd/POST_INSTALL
+++ b/system/systemd/POST_INSTALL
@@ -46,4 +46,24 @@ if [ -n "$SYSTEMD_ERROR" ]; then
   read -n 1
 fi
 
+# Generate some good default files based on current settings
+# /etc/os-release
+if [ ! -f /etc/os-release ] || ! grep -q 'HOME_URL' /etc/os-release ; then
+  if [ -f /etc/lunar.release ]; then
+    DRELEASE=$(awk '{ print $3 }' /etc/lunar.release | cut -d- -f1)
+    DCNAME=$(sed 's;.*(\(.*\) -.*;\1;' /etc/lunar.release)
+    DDESC=$(cat /etc/lunar.release)
+    DVERSION="$DRELEASE ($DCNAME)"
+  fi
+cat <<EOF > /etc/os-release
+NAME="Lunar Linux"
+VERSION="$DVERSION"
+ID=lunar
+VERSION_ID=$DRELEASE
+PRETTY_NAME="$DDESC"
+ANSI_COLOR="1;34"
+HOME_URL="http://lunar-linux.org/"
+EOF
+fi
+
 lin -c dbus

--- a/system/systemd/files/os-release
+++ b/system/systemd/files/os-release
@@ -1,4 +1,0 @@
-NAME=Lunarlinux
-ID=lunar
-PRETTY_NAME=Lunar Linux
-ANSI_COLOR=1;34


### PR DESCRIPTION
- The old file was not shell-compatible, nor did it include any real
  useful information.
