### PR TITLE
lvm2: version bumped to 2.02.97.

### DIFF
--- a/filesys/lvm2/DETAILS
+++ b/filesys/lvm2/DETAILS
@@ -1,13 +1,13 @@
           MODULE=lvm2
-         VERSION=2.02.96
+         VERSION=2.02.97
           SOURCE=LVM2.$VERSION.tgz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/LVM2.$VERSION
    SOURCE_URL[0]=ftp://sources.redhat.com/pub/lvm2
    SOURCE_URL[1]=ftp://sources.redhat.com/pub/lvm2/old
-      SOURCE_VFY=sha1:29d5097f0ca92c7665f29f862eca78bcf981ff6f
+      SOURCE_VFY=sha1:ca92d976628246745f0981d1514a79a4a8e32314
         WEB_SITE=http://sources.redhat.com/lvm2
          ENTERED=20040511
-         UPDATED=20120611
+         UPDATED=20120808
            SHORT="Logical volume manager"
 PSAFE=no
 

--- a/filesys/lvm2/POST_REMOVE
+++ b/filesys/lvm2/POST_REMOVE
@@ -1,8 +1,0 @@
-# Remove dangling symlinks
-cd /lib  &&
-rm -f libdevmapper-event-lvm2mirror.so libdevmapper-event-lvm2raid.so libdevmapper-event-lvm2snapshot.so
-cd /sbin  &&
-rm -f lvmchange lvmdiskscan lvmsadc lvmsar lvreduce lvremove lvrename lvresize lvs lvscan pvchange pvck pvcreate pvdisplay pvmove pvremove pvresize pvs pvscan vgcfgbackup vgcfgrestore vgchange vgck vgconvert vgcreate vgdisplay vgexport vgextend vgimport vgmerge vgmknodes vgreduce vgremove vgrename vgs vgscan vgsplit
-cd /usr/lib  &&
-rm -f libdevmapper-event-lvm2.so libdevmapper-event.so libdevmapper.so liblvm2cmd.so
-


### PR DESCRIPTION
Remove POST_REMOVE file as it's not needed now.
Installwatch patch from v4hn does a great job.
