### PR TITLE
installwatch: second version of the at-support/realpath patch & minor cleanup

### DIFF
--- a/utils/installwatch/BUILD
+++ b/utils/installwatch/BUILD
@@ -2,10 +2,10 @@
 
   patch_it $SOURCE_CACHE/$SOURCE2 1  &&
 
-  sedit  "s:PREFIX=/usr/local:PREFIX=/usr:"  Makefile
-  sedit  "s/gcc /gcc $CFLAGS /"              Makefile
+  sedit  "s:PREFIX=/usr/local:PREFIX=/usr:"  Makefile &&
+  sedit  "s/gcc /gcc $CFLAGS /"              Makefile &&
 
-  default_make
+  default_make &&
 
   # since the installwatch module cannot track itself when it's
   # overwritten we need to assure it goes in the log/cache:

--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -1,15 +1,15 @@
           MODULE=installwatch
          VERSION=0.6.3
           SOURCE=$MODULE-$VERSION.tgz
-         SOURCE2=$MODULE-$VERSION-at_support_realpathfix.patch.gz
+         SOURCE2=$MODULE-$VERSION-at_support_realpathfix2.patch.gz
    SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
    SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
      SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha1:e6090aaae6e6df8af11913efa4eb056d0ac07ade
-     SOURCE2_VFY=sha1:770b987fbff98abddef0182fca39c86df6c67c1c
+     SOURCE2_VFY=sha1:44f27df584568ee75fab0cd483e861bda22e3b41
         WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
          ENTERED=20011230
-         UPDATED=20120727
+         UPDATED=20120911
            SHORT="utility for tracking files from installation of software"
 
 cat << EOF


### PR DESCRIPTION
As I already mentioned earlier I knew something is wrong with my patch.
This second version fixes a number of small but in some cases harmful bugs.
