### PR TITLE
libmpc: version bumped to 1.0.

### DIFF
--- a/libs/libmpc/BUILD
+++ b/libs/libmpc/BUILD
@@ -1,7 +1,18 @@
 (
 
-  OPTS+=" --disable-static" &&
+  OPTS+=" --disable-static"  &&
 
-  default_build
+  if [ -f /usr/lib/libmpc.so.2.0.0 ]; then
+#    preserve the old version to prevent the crash of gcc
+     cp /usr/lib/libmpc.so.2.0.0 /usr/lib/libmpc.so.2.0.0.old
+   fi  &&
+
+   default_build  &&
+
+  if [ -f /usr/lib/libmpc.so.2.0.0.old ]; then
+#    restore the old version to prevent the crash of gcc
+     mv -f /usr/lib/libmpc.so.2.0.0.old /usr/lib/libmpc.so.2.0.0
+     ln -sf /usr/lib/libmpc.so.2.0.0 /usr/lib/libmpc.so.2
+   fi
 
 ) > $C_FIFO 2>&1

--- a/libs/libmpc/DETAILS
+++ b/libs/libmpc/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libmpc
-         VERSION=0.8.2
+         VERSION=1.0
           SOURCE=mpc-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/mpc-$VERSION
       SOURCE_URL=http://www.multiprecision.org/mpc/download
-      SOURCE_VFY=sha1:339550cedfb013b68749cd47250cd26163b9edd4
+      SOURCE_VFY=sha1:20af7cc481433c019285a2c1757ac65e244e1e06
         WEB_SITE=http://www.multiprecision.org
          ENTERED=20100416
-         UPDATED=20100619
+         UPDATED=20120816
            SHORT="A complex floating-point library"
 
 cat << EOF


### PR DESCRIPTION
For testing purspose. It preserves the old version of libmpc in order to allow gcc functioning.
The old version can be removed after the rebuild of the gcc and glibc
modules using the new version of the library.
