### PR TITLE
libmpc: version bumped to 1.0.1.

### DIFF
--- a/libs/libmpc/BUILD
+++ b/libs/libmpc/BUILD
@@ -1,7 +1,18 @@
 (
 
-  OPTS+=" --disable-static" &&
+  OPTS+=" --disable-static"  &&
 
-  default_build
+  if [ -f /usr/lib/libmpc.so.2.0.0 ]; then
+#    preserve the old version to prevent the crash of gcc
+     cp /usr/lib/libmpc.so.2.0.0 /usr/lib/libmpc.so.2.0.0.old
+   fi  &&
+
+   default_build  &&
+
+  if [ -f /usr/lib/libmpc.so.2.0.0.old ]; then
+#    restore the old version to prevent the crash of gcc
+     mv -f /usr/lib/libmpc.so.2.0.0.old /usr/lib/libmpc.so.2.0.0
+     ln -sf /usr/lib/libmpc.so.2.0.0 /usr/lib/libmpc.so.2
+   fi
 
 ) > $C_FIFO 2>&1

--- a/libs/libmpc/DETAILS
+++ b/libs/libmpc/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libmpc
-         VERSION=0.8.2
+         VERSION=1.0.1
           SOURCE=mpc-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/mpc-$VERSION
       SOURCE_URL=http://www.multiprecision.org/mpc/download
-      SOURCE_VFY=sha1:339550cedfb013b68749cd47250cd26163b9edd4
+      SOURCE_VFY=sha1:8c7e19ad0dd9b3b5cc652273403423d6cf0c5edf
         WEB_SITE=http://www.multiprecision.org
          ENTERED=20100416
-         UPDATED=20100619
+         UPDATED=20120908
            SHORT="A complex floating-point library"
 
 cat << EOF


### PR DESCRIPTION
For testing purposes. The module keeps the old libmpc.so.2.0.0 file
 in order to keep gcc functioning. After relin of the gcc and glibc
 the old lib file can be removed.
