### PR TITLE
grub2: Don't explicitly require grub-mkfont

### DIFF
--- a/system/grub2/BUILD
+++ b/system/grub2/BUILD
@@ -7,7 +7,6 @@
     --enable-mm-debug \
     --enable-nls \
     --enable-cache-stats \
-    --enable-grub-mkfont \
     --disable-werror \
     --with-bootdir=/boot \
     --with-grubdir=grub " &&


### PR DESCRIPTION
grub-mkfont requires freetype. If not explicitlly requested, grub-mkfont will be guessed based upon freetype. Issue #88
