### PR TITLE
binutils: add missing ampersands in BUILD

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -8,7 +8,7 @@
   make tooldir=/usr install  &&
   make tooldir=/usr install-info  &&
   mkdir -p $DOCUMENT_DIRECTORY/binutils  &&
-  cp -p binutils/NEWS binutils/ChangeLog $DOCUMENT_DIRECTORY/binutils
+  cp -p binutils/NEWS binutils/ChangeLog $DOCUMENT_DIRECTORY/binutils &&
 
   # For some reason installwatch fail to pick up the ld hardlink, touching it solves that issue
   [ -e /usr/bin/ld ] && touch /usr/bin/ld


### PR DESCRIPTION
This reveals a larger bug in binutils over here. Actually the binutils build
seems to be broken for some time!

This needs proper fixing soon!
