### PR TITLE
installwatch: new patch version

### DIFF
--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -1,15 +1,16 @@
           MODULE=installwatch
          VERSION=0.6.3
           SOURCE=$MODULE-$VERSION.tgz
-         SOURCE2=$MODULE-$VERSION-at_support_realpathfix3.patch.gz
+         SOURCE2=$MODULE-$VERSION-at_support_realpathfix4.patch.gz
    SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
    SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
      SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha1:e6090aaae6e6df8af11913efa4eb056d0ac07ade
-     SOURCE2_VFY=sha1:9be11b1101174419af3be14e65678a55e7f85ee6
+     SOURCE2_VFY=sha1:e4fb1f283045313f3942bc92ed7ea3d32b83bafd
         WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
          ENTERED=20011230
-         UPDATED=20120812
+         UPDATED=20121201
+      MAINTAINER=v4hn@lunar-linux.org
            SHORT="utility for tracking files from installation of software"
 
 cat << EOF


### PR DESCRIPTION
The new patch fixes a stupid bug that caused the following behaviour: touch
foo ln -s foo bar LD_PRELOAD=/usr/lib/installwatch.so ln -s foo bar
=> this logged something like "-1 symlink foo foo #failed" before now it
correctly logs "-1 symlink foo bar #failed"
