### PR TITLE
mpfr: version bumped to 3.1.2.

### DIFF
--- a/libs/mpfr/BUILD
+++ b/libs/mpfr/BUILD
@@ -1,7 +1,18 @@
 (
 
-  OPTS+=" --disable-static" &&
+  OPTS+=" --disable-static"  &&
 
-  default_build
+  if [ -f /usr/lib/libmpfr.so.1.2.2 ]; then
+#    preserve the old version to prevent the crash of gcc
+     cp /usr/lib/libmpfr.so.1.2.2 /usr/lib/libmpfr.so.1.2.2.old
+   fi  &&
+
+   default_build  &&
+
+  if [ -f /usr/lib/libmpfr.so.1.2.2.old ]; then
+#    restore the old version to prevent the crash of gcc
+     mv -f /usr/lib/libmpfr.so.1.2.2.old /usr/lib/libmpfr.so.1.2.2
+     ln -sf /usr/lib/libmpfr.so.1.2.2 /usr/lib/libmpfr.so.1
+   fi
 
 ) > $C_FIFO 2>&1

--- a/libs/mpfr/DETAILS
+++ b/libs/mpfr/DETAILS
@@ -1,11 +1,11 @@
           MODULE=mpfr
-         VERSION=2.4.2
+         VERSION=3.1.2
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://www.mpfr.org/$MODULE-$VERSION
-      SOURCE_VFY=sha1:7ca93006e38ae6e53a995af836173cf10ee7c18c
+      SOURCE_VFY=sha1:46d5a11a59a4e31f74f73dd70c5d57a59de2d0b4
         WEB_SITE=http://www.mpfr.org
          ENTERED=20070111
-         UPDATED=20091201
+         UPDATED=20130316
            SHORT="C library for multiple-precision floating-point computations"
 
 cat << EOF


### PR DESCRIPTION
For testing purposes. For testing purposes. The module keeps the old libmpfr.so.1.2.2 file
 in order to keep gcc functioning. After relin of the gcc and glibc
 the old lib file can be removed.
