### PR TITLE
glibc: specify build and host in BUILD

### DIFF
--- a/libs/glibc/BUILD
+++ b/libs/glibc/BUILD
@@ -45,6 +45,8 @@
                --without-gd               \
                --without-cvs              \
                --enable-shared            \
+               --host=$BUILD              \
+               --build=$BUILD             \
                --enable-obsolete-rpc      \
                --disable-multi-arch       \
                --enable-bind-now          \


### PR DESCRIPTION
compiling fails in a i686 chroot on a x86_64 platform without this.
