### PR TITLE
lunar: slightly adjust autocomplete

### DIFF
--- a/system/lunar/profile.d/lunar.rc
+++ b/system/lunar/profile.d/lunar.rc
@@ -125,11 +125,11 @@ _lunar_lvu()
       COMPREPLY=( $(compgen -f -- "$cur") )
       return 0
       ;;
-    DETAILS|DEPENDS|CONFLICTS|BUILD|PRE_BUILD|POST_BUILD|CONFIGURE|POST_INSTALL|PRE_REMOVE|POST_REMOVE|what|where|cd|service|website|compiler|links|sources|maintainer|version|sum|md5sum|depends|tree|eert|stree|leert|urls|versions|short|info|edit)
+    DETAILS|DEPENDS|CONFLICTS|BUILD|PRE_BUILD|POST_BUILD|CONFIGURE|POST_INSTALL|PRE_REMOVE|POST_REMOVE|what|where|cd|service|website|compiler|links|sources|maintainer|version|sum|md5sum|depends|tree|eert|stree|leert|urls|versions|short|info|edit|compile|installed)
       _lunar_modules_list
       return 0
       ;;
-    compile|install|installed|size)
+    install|size)
       _lunar_modules_installed_list
       return 0
       ;;


### PR DESCRIPTION
`lvu installed` and `lvu compile` should also autocomplete for modules which
failed to install/are not installed.

That one has been nagging me for ages...
