### PR TITLE
lunar: introduce lwtf and lcd functions

### DIFF
--- a/system/lunar/profile.d/lunar.rc
+++ b/system/lunar/profile.d/lunar.rc
@@ -159,6 +159,25 @@ _lunar_lvu()
 }
 complete -F _lunar_lvu lvu
 
+_lunar_comp_modules()
+{
+  local cur
+  cur=${COMP_WORDS[COMP_CWORD]}
+  _lunar_modules_list
+  return 0
+}
+
+alias lwtf="lvu what"
+complete -F _lunar_comp_modules lwtf
+
+function lcd(){
+  [[ -z "$1" || "$1" = "." ]] &&
+    cd "$(lsh 'echo $MOONBASE')" ||
+    cd "$(lsh "echo \$MOONBASE/\$(find_section $1)/$1")"
+  return 0
+}
+complete -F _lunar_comp_modules lcd
+
 _lunar_lin()
 {
   local cur


### PR DESCRIPTION
These functions have been incredibly helpful to me in the last years and I
think it's time to include them in the official lunar module.

Yes, there is `lvu what`, but `lwtf` is shorter and has more style :). Also,
it mimics the standard `wtf` tool.

Yes, there is `lvu cd` but that opens a non-interactive subshell for each use
of the function and also drops PS1 etc. Using a bash function for that enables
us to jump between many modules keeping the same shell environment.
