### PR TITLE
iproute2: version bumped to 3.9.0 and gcc patch

### DIFF
--- a/net/iproute2/BUILD
+++ b/net/iproute2/BUILD
@@ -1,15 +1,14 @@
-(
+patch_it $SOURCE2 1 &&
 
-  patch_it $SOURCE2 1 &&
-  patch_it $SOURCE3 1 &&
+# fixed in next version
+# http://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/commit/?id=824c843556a80cd3b4003d1e9e583cfdf632d0c0
+sedit "s:sizeof(th\.hdr\[i\]):HDR_LINE_LENGTH:" misc/lnstat.c &&
 
-  if ! in_depends $MODULE db; then
-    sedit 's/arpd//' misc/Makefile
-  fi &&
+if ! in_depends $MODULE db; then
+  sedit 's/arpd//' misc/Makefile
+fi &&
 
-  ./configure &&
-  KERNEL_INCLUDE=/usr/include/ make &&
-  prepare_install &&
-  make install
-
-) > $C_FIFO 2>&1
+./configure &&
+KERNEL_INCLUDE=/usr/include/ make &&
+prepare_install &&
+make install

--- a/net/iproute2/DETAILS
+++ b/net/iproute2/DETAILS
@@ -1,17 +1,14 @@
           MODULE=iproute2
-         VERSION=3.8.0
+         VERSION=3.9.0
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=$MODULE-fhs.patch.bz2
-         SOURCE3=$MODULE-no-iptables.patch
       SOURCE_URL=http://www.kernel.org/pub/linux/utils/net/$MODULE
      SOURCE2_URL=$PATCH_URL
-     SOURCE3_URL=$PATCH_URL
-      SOURCE_VFY=sha1:6d40dd2b91aad9ae084c99973dcdfdbf6fb353fc
+      SOURCE_VFY=sha1:3f48a6d3019f1766f26cda6c4de5d3858837d92b
      SOURCE2_VFY=sha1:b39063237e7a2c68fcfb731fe5bf5b3177e1b2dc
-     SOURCE3_VFY=sha1:2ceac0fad93166ab2c4070b78c6d563c9808fa93
         WEB_SITE=http://www.linuxfoundation.org/collaborate/workgroups/networking/$MODULE
          ENTERED=20021106
-         UPDATED=20130323
+         UPDATED=20130518
            SHORT="Professional tools to control networking in Linux kernels"
 
 cat << EOF


### PR DESCRIPTION
This is an improved version of florin's pull-request.
Please reject his and merge this instead.

gcc 4.8 complains about a bug that was fixed directly
after the 3.9.0 release....
