### PR TITLE
installwatch: now support utime/utimensat syscalls

### DIFF
--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -1,15 +1,15 @@
           MODULE=installwatch
          VERSION=0.6.3
           SOURCE=$MODULE-$VERSION.tgz
-         SOURCE2=$MODULE-$VERSION-at_support_realpathfix5.patch.gz
+         SOURCE2=$MODULE-$VERSION-at_support_realpathfix6.patch.gz
    SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
    SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
      SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha1:e6090aaae6e6df8af11913efa4eb056d0ac07ade
-     SOURCE2_VFY=sha1:c9d9dfebd0c393969dd61739081231b1077289f0
+     SOURCE2_VFY=sha1:357b8a204f6f51840d0dbc906dd176ab1321d86f
         WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
          ENTERED=20011230
-         UPDATED=20130102
+         UPDATED=20130606
       MAINTAINER=v4hn@lunar-linux.org
            SHORT="utility for tracking files from installation of software"
 


### PR DESCRIPTION
... so cavalier can sleep relaxed again
