### PR TITLE
gcc: -D_FORTIFY_SOURCE=2 is a preprocessor flag and does not belong in C...

### DIFF
--- a/compilers/gcc/plugin.d/optimize-gcc_4_8.plugin
+++ b/compilers/gcc/plugin.d/optimize-gcc_4_8.plugin
@@ -129,7 +129,7 @@ plugin_compiler_gcc_4_8_optimize()
         c_cxx_flags_add "-pipe"
         ;;
       Fortify)
-        c_cxx_flags_add "-D_FORTIFY_SOURCE=2"
+        cppflags_add "-D_FORTIFY_SOURCE=2"
         ;;
       StackProt)
         c_cxx_flags_add "-fstack-protector"


### PR DESCRIPTION
-D_FORTIFY_SOURCE=2 is a preprocessor flag and does not belong in CFLAGS/CXXFLAGS
