### PR TITLE
findutils: version bumped to 4.4.2.

### DIFF
--- a/utils/findutils/DETAILS
+++ b/utils/findutils/DETAILS
@@ -1,14 +1,11 @@
           MODULE=findutils
-         VERSION=4.5.10
+         VERSION=4.4.2
           SOURCE=$MODULE-$VERSION.tar.gz
-# Early versions are not held on mirror  and major download sites
-# Uncomment this when findutils will be released officially.
-#   SOURCE_URL[0]=$GNU_URL/$MODULE
-   SOURCE_URL[1]=ftp://alpha.gnu.org/gnu/findutils
-      SOURCE_VFY=sha1:e984c8795cb495623ff50ee319c8c0d8843d9bc2
-        WEB_SITE=http://www.gnu.org/software/findutils/
+      SOURCE_URL=$GNU_URL/$MODULE
+      SOURCE_VFY=sha1:e8dd88fa2cc58abffd0bfc1eddab9020231bb024
+        WEB_SITE=http://www.gnu.org/software/$MODULE
          ENTERED=20010922
-         UPDATED=20110515
+         UPDATED=20130731
            SHORT="Utilities for locating files"
 
 cat << EOF


### PR DESCRIPTION
This is the last stable version.
