### PR TITLE
vim: lua interp broken as well

### DIFF
--- a/editors/vim/BUILD
+++ b/editors/vim/BUILD
@@ -1,6 +1,4 @@
-(
-
-  OPTS+=" --disable-perlinterp"
+  OPTS+=" --disable-perlinterp --disable-luainterp" &&
 
   cd src           &&
   default_config   &&
@@ -11,5 +9,3 @@
   make install                        &&
   ln  -sf  /usr/bin/vim  /usr/bin/vi  &&
   cp -f $SCRIPT_DIRECTORY/vimrc /usr/share/vim/vim${MAJOR}/sample.vimrc
-
-) > $C_FIFO 2>&1

--- a/editors/vim/DEPENDS
+++ b/editors/vim/DEPENDS
@@ -3,8 +3,13 @@ depends ncurses
 optional_depends "acl"    "--enable-acl"               "--disable-acl"               "for Access Control List support"
 optional_depends "gpm"    "--enable-gpm"               "--disable-gpm"               "for GPM mouse support"
 optional_depends "libX11" "--enable-gui=auto --with-x" "--enable-gui=no --without-x" "for Graphical User Interface support"
-optional_depends "Python" "--enable-pythoninterp"      "--disable-pythoninterp"      "for Python interpreter support"
-#optional_depends "perl"   "--enable-perlinterp"        "--disable-perlinterp"        "for Perl interpreter support"
+
+# broken in 7.3 due to API changes
+# these should work again with the upcoming 7.4 release
+#optional_depends "perl"   "--enable-perlinterp" "--disable-perlinterp"        "for Perl interpreter support"
+#optional_depends "lua"    "--enable-luainterp"  "--disable-luainterp"         "for Lua interpreter support"
+
+optional_depends "Python"   "--enable-pythoninterp"  "--disable-pythoninterp"      "for Python interpreter support"
+optional_depends "Python-3" "--enable-python3interp" "--disable-python3interp" "for Python 3 interpreter support"
+optional_depends "ruby"   "--enable-rubyinterp"  "--disable-rubyinterp"        "for Ruby interpreter support"
 optional_depends "tcl"    "--enable-tclinterp"         "--disable-tclinterp"         "for Tcl interpreter support"
-optional_depends "ruby"   "--enable-rubyinterp"        "--disable-rubyinterp"        "for Ruby interpreter support"
-optional_depends "lua"    "--enable-luainterp"         "--disable-luainterp"         "for Lua interpreter support"


### PR DESCRIPTION
add python3 interpreter dependency & disable lua until vim 7.4 fixed lua 5.2
problems.
