### PR TITLE
wget: fixed bug in pod generation

### DIFF
--- a/ftp/wget/BUILD
+++ b/ftp/wget/BUILD
@@ -1,5 +1,3 @@
-(
-
   # get the alias
   SSL=`unalias %SSL` &&
 
@@ -27,5 +25,3 @@
               $OPTS                     &&
 
    default_make
-
-) > $C_FIFO 2>&1

--- a/ftp/wget/PRE_BUILD
+++ b/ftp/wget/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit 's@=item $thing@=item ${thing}".($thing =~ /[0-9]+/ ? "Z<>" : "")."@' doc/texi2pod.pl


### PR DESCRIPTION
This fixes a bug involving pod2man which seems to interpret numbers after
=item as text if not properly indicated

http://permalink.gmane.org/gmane.comp.web.wget.general/11750
