### PR TITLE
glibc: Remove warning _FORTIFY_SOURCE -O

### DIFF
--- a/libs/glibc/PRE_BUILD
+++ b/libs/glibc/PRE_BUILD
@@ -1,3 +1,3 @@
 default_pre_build &&
 
-sedit '/^#\s*warning \+_FORTIFY_SOURCE requires compiling with optimization/d' include/features.h
+sedit 's@^#\s*warning \+_FORTIFY_SOURCE requires compiling with optimization.*$@/* Disabled by lunar as there is no better solution: \0*/@' include/features.h


### PR DESCRIPTION
autoconf header checks breaks on this.
Most mainstream distros choose to remove this warning.
