### PR TITLE
kmod: Depends on bash-completion.

### DIFF
--- a/kernel/kmod/DEPENDS
+++ b/kernel/kmod/DEPENDS
@@ -1,6 +1,7 @@
 depends  zlib
 depends  automake
 depends  libtool
+depends  bash-completion
 
 optional_depends  "xz"  "--with-xz"  "--without-xz"  "support for xz compressed modules"
 optional_depends  "docbook-xsl" "" "--disable-manpages" "build manpages"


### PR DESCRIPTION
This make the kmod bash-completion file being installed in the correct
location.
