### PR TITLE
Module gc: Source Page moved

### DIFF
--- a/devel/gc/DETAILS
+++ b/devel/gc/DETAILS
@@ -1,9 +1,9 @@
           MODULE=gc
          VERSION=7.4.0
           SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://www.hpl.hp.com/personal/Hans_Boehm/gc/gc_source
+      SOURCE_URL=http://www.hboehm.info/gc/gc_source
       SOURCE_VFY=sha1:82f031a5a6db004df3cf8f1b1e72dd6b313ab032
-        WEB_SITE=http://www.hpl.hp.com/personal/Hans_Boehm/gc
+        WEB_SITE=http://www.hboehm.info/gc/
          ENTERED=20020314
          UPDATED=20140115
            SHORT="A garbage collector"


### PR DESCRIPTION
The source page for the module gc moved. HP put down the website and Hans Boehm uploaded the page on this private web server. Also the homepage of gc has moved.
