### PR TITLE
readline: version bumped to 6.2 patchlevel 005.

### DIFF
--- a/libs/readline/BUILD
+++ b/libs/readline/BUILD
@@ -1,7 +1,5 @@
 (
 
-  patch_it $SOURCE2 0 &&
-
   # Real and working fix for readline 5 to 6 upgrade
   # Especially workaround issue when you would like to lin again readline 6 after lining readline 6 already
   mkdir -p /tmp/old.libraries &&

--- a/libs/readline/DETAILS
+++ b/libs/readline/DETAILS
@@ -1,18 +1,15 @@
           MODULE=readline
          VERSION=6.2
+        PATCHLVL=005
+        RSAIDKEY=64EA74AB
           SOURCE=$MODULE-$VERSION.tar.gz
-         SOURCE2=readline62-001
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.cwru.edu/pub/bash
    SOURCE_URL[2]=ftp://ftp.gnu.org/pub/gnu/$MODULE
       SOURCE_VFY=sha1:a9761cd9c3da485eb354175fcc2fe35856bc43ac
-  SOURCE2_URL[0]=$GNU_URL/$MODULE/$MODULE-$VERSION-patches
-  SOURCE2_URL[1]=ftp://ftp.cwru.edu/pub/bash/$MODULE-$VERSION-patches
-  SOURCE2_URL[2]=ftp://ftp.gnu.org/pub/gnu/$MODULE/$MODULE-$VERSION-patches
-     SOURCE2_VFY=sha1:7d264c281f3b43e1c07c020b1785631411ce039e
         WEB_SITE=http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
          ENTERED=20010922
-         UPDATED=20110301
+         UPDATED=20140417
            SHORT="Lets users edit command lines as they are typed in"
 
 cat << EOF

--- a/libs/readline/PRE_BUILD
+++ b/libs/readline/PRE_BUILD
@@ -1,0 +1,31 @@
+cd     $BUILD_DIRECTORY  &&
+unpack $SOURCE           &&
+
+# patch #009 need it
+ln -sf $MODULE-$VERSION $MODULE-$VERSION-patched  &&
+
+if [[ $((10#${PATCHLVL})) -gt 0 ]]; then
+
+# get the RSA Key for patches verification
+  gpg --no-default-keyring --keyring vendors.gpg --keyserver pgp.mit.edu --recv-key $RSAIDKEY  &&
+
+  cd $BUILD_DIRECTORY  &&
+
+  for (( _p=1; _p<=$((10#${PATCHLVL})); _p++ )); do
+    SOURCE2=$MODULE${VERSION//.}-$(printf "%03d" $_p)  &&
+    PATCH2_URL=http://ftp.gnu.org/gnu/$MODULE/$MODULE-$VERSION-patches/$SOURCE2
+    wget $PATCH2_URL{,.sig}  &&
+    gpg --verify --verbose --keyring vendors.gpg ./$SOURCE2.sig  &&
+    message "Applying patch "$SOURCE2  &&
+    patch_it ./$SOURCE2 1
+    rm ${SOURCE2}*
+  done
+
+fi
+
+rm $MODULE-$VERSION-patched  &&
+
+cd $SOURCE_DIRECTORY
+
+# use this command in order to get the value of RSAIDKEY
+#gpg --verify <file.sig>


### PR DESCRIPTION
Same as for bash, bash_static modules.
