### PR TITLE
zlib: install libz.a to /lib together with the .so's

### DIFF
--- a/archive/zlib/BUILD
+++ b/archive/zlib/BUILD
@@ -1,5 +1,3 @@
-(
-
   sedit "s:\${libdir}/pkgconfig:/usr/lib/pkgconfig:" Makefile.in  &&
 
   export CFLAGS="$CFLAGS -fPIC"  &&
@@ -11,12 +9,4 @@
                --libdir=/lib  \
                --shared       &&
 
-  default_make  &&
-
-  # for systems without /bin -> /usr/bin symlink
-  if [ "`cd /usr/bin; pwd -P`" != "`cd /bin; pwd -P`" ]; then
-    cp libz.a /usr/lib  &&
-    rm /lib/libz.a
-  fi
-
-) > $C_FIFO 2>&1
+  default_make

--- a/archive/zlib/DETAILS
+++ b/archive/zlib/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha1:a4d316c404ff54ca545ea71a27af7dbc29817088
         WEB_SITE=http://www.zlib.net
          ENTERED=20010922
-         UPDATED=20130429
+         UPDATED=20140709
            SHORT="lossless data compression library"
 
 cat << EOF


### PR DESCRIPTION
The static build should be together with the shared lib.