### PR TITLE
rsync: version bump.

### DIFF
--- a/net/rsync/DETAILS
+++ b/net/rsync/DETAILS
@@ -1,12 +1,12 @@
           MODULE=rsync
-         VERSION=3.1.0
+         VERSION=3.1.1
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://rsync.samba.org/ftp/$MODULE
    SOURCE_URL[1]=ftp://rsync.samba.org/pub/$MODULE
-      SOURCE_VFY=sha1:eb58ab04bcb6293da76b83f58327c038b23fcba3
+      SOURCE_VFY=sha256:7de4364fcf5fe42f3bdb514417f1c40d10bbca896abe7e7f2c581c6ea08a2621
         WEB_SITE=http://rsync.samba.org
          ENTERED=20010922
-         UPDATED=20131001
+         UPDATED=20140723
            SHORT="A replacement for rcp"
            PSAFE=no
 


### PR DESCRIPTION
When a new version of rsync is released, the previous version gets deleted from the download site.  So it would probably be a good idea to merge this one soon.
