### PR TITLE
btrfs-progs: version bump to 3.14.2

### DIFF
--- a/filesys/btrfs-progs/BUILD
+++ b/filesys/btrfs-progs/BUILD
@@ -1,7 +1,6 @@
 (
 
-  sedit 's/^prefix.*/prefix = \//' Makefile
-  sedit 's/\/local//' man/Makefile &&
+  sedit 's/^prefix.*/prefix = \/usr/' Makefile
   sedit 's/^bindir.*/bindir = \/sbin/' Makefile &&
 
   make &&

--- a/filesys/btrfs-progs/DETAILS
+++ b/filesys/btrfs-progs/DETAILS
@@ -1,12 +1,12 @@
           MODULE=btrfs-progs
-         VERSION=v0.20-rc1
-          SOURCE=${MODULE}-${VERSION}.tar.bz2
+         VERSION=v3.14.2
+          SOURCE=${MODULE}-${VERSION}.tar.xz
       SOURCE_URL=http://www.kernel.org/pub/linux/kernel/people/mason/btrfs-progs
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha1:744d391d7cf7d20cdd2627fb6ef6f43876552751
+      SOURCE_VFY=sha256:70e1d0ca887bfa5062dc74cc5d4556c19adb08453fbfa57edae6802d9c917793
         WEB_SITE=http://btrfs.wiki.kernel.org/index.php/Main_Page
          ENTERED=20090819
-         UPDATED=20090819
+         UPDATED=20140729
            SHORT="btrfs userspace tools"
 
 cat <<EOF


### PR DESCRIPTION
btrfs-progs needs to be bumped to the latest version for docker to compile.

This also fixes some problems introduced by the big version jump.
