### PR TITLE
binutils: Changing to out of source build as recommended by the binutil ...

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -1,5 +1,11 @@
-./configure  --prefix=/usr    \
-             --disable-werror \
+
+# Following the build procedure used by the LFS folks
+mkdir -p build-binutils &&
+cd build-binutils &&
+
+../configure  --prefix=/usr    \
+              --disable-werror \
+              --enable-shared  \
              $OPTS         &&
 
 make tooldir=/usr          &&
@@ -7,7 +13,7 @@ prepare_install            &&
 make tooldir=/usr install  &&
 make tooldir=/usr install-info  &&
 mkdir -p $DOCUMENT_DIRECTORY/binutils  &&
-cp -p binutils/NEWS binutils/ChangeLog $DOCUMENT_DIRECTORY/binutils &&
+cp -p ../binutils/NEWS ../binutils/ChangeLog $DOCUMENT_DIRECTORY/binutils &&
 
 # For some reason installwatch fail to pick up the ld hardlink, touching it solves that issue
 if [ -e /usr/bin/ld ]; then

--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -6,7 +6,7 @@
       SOURCE_VFY=sha1:1b2bc33003f4997d38fadaa276c1f0321329ec56
         WEB_SITE=http://sources.redhat.com/binutils
          ENTERED=20010922
-         UPDATED=20131202
+         UPDATED=20140808
            SHORT="An essential collection of binary utilities"
 
 cat << EOF


### PR DESCRIPTION
...folks and

enabling shared.

Short story;
attempt to bump tulip to 4.5.0.
make fails on bfd stuff
consult all knowing google
find patch from arch folks switching bfd to liberty
make fails with ld not finding liberty
look in binutils and source, we don't install liberty
v4hn mention stackoverflow and so files for bfd and others
find; http://www.linuxfromscratch.org/lfs/view/development/chapter06/binutils.html
try their build process
binutils now has; /usr/lib/libbfd-2.24.so /usr/lib/libbfd.so /usr/lib/libopcodes-2.24.so and /usr/lib/libopcodes.so in addition to the original .a files
recompile tulip sans any patches- compiled fine

recompiled gcc and glibc just to see - all was well
