### PR TITLE
btrfs: added dependency on lzo.

### DIFF
--- a/filesys/btrfs-progs/DEPENDS
+++ b/filesys/btrfs-progs/DEPENDS
@@ -1,0 +1,1 @@
+depends lzo


### PR DESCRIPTION
Thanks to freenode user Guest37789 for pointing this out.
