### PR TITLE
lunar: version bumped to 12

### DIFF
--- a/system/lunar/DETAILS
+++ b/system/lunar/DETAILS
@@ -1,12 +1,12 @@
           MODULE=lunar
-         VERSION=11
+         VERSION=12
           SOURCE=$MODULE-$VERSION.tar.bz2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://lunar-linux.org/lunar/lunar/
-      SOURCE_VFY=sha1:354ef4b5da3393e8a27ead922fa6db4f596e5fec
+      SOURCE_VFY=sha256:499b297c2cabb6ad3f1d5269891a9ce6288e87d7cd9e2dcb265d7004fe3c301c
         WEB_SITE=http://lunar-linux.org/
          ENTERED=20020218
-         UPDATED=20130904
+         UPDATED=20140819
            SHORT="lunar contains the package management tools for Lunar-Linux."
 USE_WRAPPERS=off
 cat << EOF


### PR DESCRIPTION
This release contain quite a few changes:
- Updated procted file list
- Properly cascade error code after plugin_call has finished
- optional_depends now have a 5th option to set the default choice (y/n)
- lvu submit is now compatible with git am
- rework module dependencies on renew
- lin temp files are now prefixed with the module name (easier tab-completion)
- add_priv_*() no longer exit the whole build if they fail for some reason
- only detect module in zlocal if a DETAILS file exists
- SOURCE1 is no longer valid in DETAILS, should be SOURCE SOURCE2
- Support for SOURCE_FULL_URLx to allow download from sites which generate a
  tarball with an odd filename
- A number of bugs and internal changes fixed
