### PR TITLE
Python: don't build byte code of site-packages

### DIFF
--- a/python/Python/BUILD
+++ b/python/Python/BUILD
@@ -1,13 +1,3 @@
-(
-
-# This fixes some import not being installed when compiled against kernels 3.x
-  if [ `uname -r | cut -c 1` == "3" ] ; then
-    mkdir Lib/plat-linux3 &&
-    cp Lib/plat-linux2/* Lib/plat-linux3/
-  fi &&
-
-  sedit "s:-O3:$CFLAGS -Os:g" configure  &&
-
   OPTS+=" --enable-shared"  &&
 
   default_build &&
@@ -21,5 +11,3 @@
   mv Misc/{cheatsheet,NEWS} .  &&
   chmod 644 cheatsheet NEWS README  &&
   gather_docs cheatsheet NEWS README
-
-) > $C_FIFO 2>&1

--- a/python/Python/DETAILS
+++ b/python/Python/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha1:9c6281eeace0c3646fa556c8087bb1b7e033c9c4
         WEB_SITE=http://www.python.org
          ENTERED=20010922
-         UPDATED=20140708
+         UPDATED=20141013
            PSAFE=no
            SHORT="Interpreted, interactive, object-oriented programming language"
 

--- a/python/Python/PRE_BUILD
+++ b/python/Python/PRE_BUILD
@@ -1,0 +1,11 @@
+default_pre_build &&
+
+# This fixes some import not being installed when compiled against kernels 3.x
+if [ `uname -r | cut -c 1` == "3" ] ; then
+  mkdir Lib/plat-linux3 &&
+  cp Lib/plat-linux2/* Lib/plat-linux3/
+fi &&
+
+sedit "s:-O3:$CFLAGS -Os:g" configure  &&
+
+sedit "s/ badsyntax / 'badsyntax|site-packages' /" Makefile.pre.in


### PR DESCRIPTION
This stops Python from complaining whenever a Python module was removed..
The modules are supposed to build their byte code on their own.
