### PR TITLE
Update kmod and usbutils to use $KERNEL_SRC

### DIFF
--- a/kernel/kmod/DETAILS
+++ b/kernel/kmod/DETAILS
@@ -1,7 +1,7 @@
           MODULE=kmod
          VERSION=19
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=ftp://ftp.kernel.org/pub/linux/utils/kernel/$MODULE
+      SOURCE_URL=$KERNEL_URL/pub/linux/utils/kernel/$MODULE
       SOURCE_VFY=sha256:3e7fee6eeff5435848b2dcc852bc8959066478d687d232284d67300c071e7b14
         WEB_SITE=http://www.politreco.com/2011/12/announce-kmod-1
          ENTERED=20120115

--- a/utils/usbutils/DETAILS
+++ b/utils/usbutils/DETAILS
@@ -2,7 +2,7 @@
          VERSION=008
           SOURCE=$MODULE-$VERSION.tar.xz
          SOURCE2=usb.ids.gz
-   SOURCE_URL[0]=http://ftp.uni-frankfurt.de/kernel/linux/utils/usb/$MODULE
+   SOURCE_URL[0]=$KERNEL_URL/pub/linux/utils/usb/$MODULE
    SOURCE_URL[1]=http://mirror.anl.gov/pub/linux/utils/usb/$MODULE
      SOURCE2_URL=http://www.linux-usb.org
       SOURCE_VFY=sha1:233dee6cd6829476be778554984045663b568b18


### PR DESCRIPTION
As the hardcoded URLs failed here, a small update to make them use the $KERNEL_SRC, to be sync with the user's configuration, nothing special, but it may help.