### PR TITLE
libpcap: Adding a patch to deal with blue-5.x. Taken from arch linux.

### DIFF
--- a/net/libpcap/BUILD
+++ b/net/libpcap/BUILD
@@ -1,8 +1,12 @@
-(
+
+  patch_it $SOURCE2 1 &&
+
+  if module_installed bluez-5 ; then
+    OPTS+=" --enable-bluetooth"
+  fi &&
 
   sedit "s/all: libpcap.a shared pcap-config/all: shared pcap-config/g" Makefile.in &&
   sedit "s/install: install-shared install-archive pcap-config/install: install-shared pcap-config/g" Makefile.in &&
 
-  default_build
 
-) > $C_FIFO 2>&1
+  default_build

--- a/net/libpcap/DETAILS
+++ b/net/libpcap/DETAILS
@@ -1,11 +1,14 @@
           MODULE=libpcap
          VERSION=1.6.2
           SOURCE=$MODULE-$VERSION.tar.gz
+         SOURCE2=libpcap-1.7.4-enable_bluetooth-1.patch
       SOURCE_URL=http://www.tcpdump.org/release
-      SOURCE_VFY=sha1:7efc7d56f4959de8bb33a92de2e15d92105eac32
+     SOURCE2_URL=$PATCH_URL
+      SOURCE_VFY=sha256:5db3e2998f1eeba2c76da55da5d474248fe19c44f49e15cac8a796a2c7e19690
+     SOURCE2_VFY=sha256:5000de2daec00fb31ccc949f7e265bfb621635c8e2daf9bb17770d75997195b5
         WEB_SITE=http://www.tcpdump.org/
          ENTERED=20011004
-         UPDATED=20141127
+         UPDATED=20150704
            SHORT="A capturing library used by tcpdump"
 
 cat << EOF


### PR DESCRIPTION
The same issue bluez with 1.6.2 as with 1.7.4 (the make tanks here) so will
still run with 1.6.2 for now.