### PR TITLE
e3: Bump to 2.8. Changes of interest to quote;

### DIFF
--- a/editors/e3/BUILD
+++ b/editors/e3/BUILD
@@ -1,14 +1,12 @@
-(
 
   if [ "`arch`" == "x86_64" ]; then
-    make nasm64
+    make EXMODE=_ 64
   else
-    make
+    make EXMODE=_ 32
   fi                               &&
+
   prepare_install                  &&
   make  BINDIR=/usr/bin             \
         MANDIR=/usr/share/man/man1  \
         PREFIX=/                    \
         install
-
-) > $C_FIFO 2>&1

--- a/editors/e3/DETAILS
+++ b/editors/e3/DETAILS
@@ -1,11 +1,11 @@
           MODULE=e3
-         VERSION=2.7.1
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://mitglied.multimania.de/albkleine
-      SOURCE_VFY=sha1:3efe3f0d463c10fe2f1ed04ff7726142df8470b4
-        WEB_SITE=http://mitglied.multimania.de/albkleine/
+         VERSION=2.8
+          SOURCE=$MODULE-$VERSION.tgz
+      SOURCE_URL=http://sites.google.com/site/e3editor/Home
+      SOURCE_VFY=sha256:035737d0cc82b287386fdff8682b2c23ef620d7ef97dff7a1b1fe1777e4c4fb7
+        WEB_SITE=https://sites.google.com/site/e3editor
          ENTERED=20010922
-         UPDATED=20071127
+         UPDATED=20150705
            SHORT="assembler written minimalistic full-screen text editor."
 
 cat << EOF


### PR DESCRIPTION
"This version was reduced down to the minimum, i.e, armlinux, e3c and elks parts are removed,
if interested still use e3-2.7.1."

Does that bother us?