### PR TITLE
elfutils: don't compile with -Werror

### DIFF
--- a/libs/elfutils/PRE_BUILD
+++ b/libs/elfutils/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+sedit 's:-Werror::g' $(grep -rl Werror)


### PR DESCRIPTION
i686 build produces a "might be used uninitialized" warning.