### PR TITLE
openssl: version bump to 1.0.2f

### DIFF
--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -12,7 +12,7 @@
      SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
         WEB_SITE=http://www.openssl.org
          ENTERED=20010922
-         UPDATED=20151204
+         UPDATED=20160211
            PSAFE="no"
            SHORT="A library for providing encrypted transport layers"
 

--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -1,5 +1,5 @@
           MODULE=openssl
-         VERSION=1.0.2e
+         VERSION=1.0.2f
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=Makefile.openssl-certs
    SOURCE_URL[0]=http://www.openssl.org/source
@@ -8,7 +8,7 @@
    SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
    SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
+      SOURCE_VFY=sha256:932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
      SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
         WEB_SITE=http://www.openssl.org
          ENTERED=20010922


### PR DESCRIPTION
Fixes a security issue and further fixes a previous issue.