### PR TITLE
irssi: version bump to 0.8.18.

### DIFF
--- a/chat/irssi/DETAILS
+++ b/chat/irssi/DETAILS
@@ -1,11 +1,11 @@
           MODULE=irssi
-         VERSION=0.8.17
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://github.com/irssi-import/irssi/releases/download/$VERSION/
-      SOURCE_VFY=sha256:3c9600cad2edf58f1d012febc1a0ba844274df6e331c01a9e935467705166807
+         VERSION=0.8.18
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=https://github.com/irssi/irssi/releases/download/$VERSION/
+      SOURCE_VFY=sha256:30043784815bb864b1bb66a82c1e659c325be0a18ddcf76fc101812e36c39c20
         WEB_SITE=http://irssi.org
          ENTERED=20020908
-         UPDATED=20141012
+         UPDATED=20160301
            SHORT="irssi: an IRC client"
 
 cat << EOF


### PR DESCRIPTION
See https://github.com/irssi/irssi/releases for details.