### PR TITLE
aliases: Add support for libressl

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,5 +1,6 @@
 %KERNEL_HEADERS:kernel-headers kernel-headers-2.6
 %KMOD:kmod module-init-tools
-%SSL:openssl gnutls
+%SSL:openssl libressl gnutls
+%OSSL:openssl libressl
 %UDEV:systemd udev
 %XMLRENDERER:libxml2 expat


### PR DESCRIPTION
Add libressl to the "%SSL" alias, and make a new alias "%OSSL"
which can be either openssl or libressl.

This is a teensy tiny harmless little change, to enable some much bigger changes soon.