### PR TITLE
iptables: Added a POST_INSTALL

### DIFF
--- a/security/iptables/POST_INSTALL
+++ b/security/iptables/POST_INSTALL
@@ -1,0 +1,1 @@
+lunar fix $(lvu depends iptables)


### PR DESCRIPTION
Updating iptables changes the names of the shared libraries it installs,
breaking modules that use them.  Run this autofix to deal with that.