### PR TITLE
flex: avoid build the man page if help2man is not installed

### DIFF
--- a/devel/flex/BUILD
+++ b/devel/flex/BUILD
@@ -1,6 +1,7 @@
-./configure --build=$BUILD \
-            --prefix=/usr  \
-            $OPTS         &&
+./configure --build=$BUILD   \
+            --prefix=/usr    \
+            --disable-static \
+            $OPTS           &&
 
 sedit 's/ln -s/ln -sf/' Makefile &&
 default_make &&

--- a/devel/flex/PRE_BUILD
+++ b/devel/flex/PRE_BUILD
@@ -1,0 +1,6 @@
+default_pre_build &&
+
+if ! module_installed help2man; then
+  # avoid building the man page
+  sedit "s:doc ::" Makefile.am
+fi


### PR DESCRIPTION
help2man is not in the core repo.