### PR TITLE
util-linux: version bumped to 2.28.

### DIFF
--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -10,14 +10,21 @@ OPTS+=" --enable-agetty     \
         --enable-newgrp     \
         --enable-write      \
         --disable-kill      \
-        --disable-last      \
         --disable-reset     \
         --disable-static    \
-        --disable-wall      \
         --enable-libmount-force-mountinfo" &&
 
+OPTS+=" --exec-prefix=/usr \
+        --enable-fs-paths-extra=/usr/bin" &&
+
 default_build &&
+
+# allow only thr root user to use wall command
+chmod 700 /usr/bin/wall &&
+
 chmod 4711 /usr/bin/{newgrp,ch{sh,fn}} &&
 install -g0 -o0 -m755 $SCRIPT_DIRECTORY/make-issue /usr/bin/make-issue &&
 
-sedit '/ListenStream/ aRuntimeDirectory=uuidd' /usr/lib/systemd/system/uuidd.socket
+if module_installed systemd; then
+  sedit '/ListenStream/ aRuntimeDirectory=uuidd' /usr/lib/systemd/system/uuidd.socket
+fi

--- a/utils/util-linux/DEPENDS
+++ b/utils/util-linux/DEPENDS
@@ -1,7 +1,8 @@
-depends Python
 depends ncurses
 depends zlib
 depends shadow
 
+optional_depends Python-3 "--with-python=3" "" "for Python 3.x support" n
+
+optional_depends Python    "" "" "for Python 2.x support"
 optional_depends Linux-PAM "" "" "for PAM support"
-optional_depends systemd   "" "" "for systemd support"

--- a/utils/util-linux/DETAILS
+++ b/utils/util-linux/DETAILS
@@ -1,12 +1,12 @@
           MODULE=util-linux
-         VERSION=2.27.1
+         VERSION=2.28
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$KERNEL_URL/pub/linux/utils/$MODULE/v${VERSION::4}
    SOURCE_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:0a818fcdede99aec43ffe6ca5b5388bff80d162f2f7bd4541dca94fecb87a290
+      SOURCE_VFY=sha256:395847e2a18a2c317170f238892751e73a57104565344f8644090c8b091014bb
         WEB_SITE=http://freecode.com/projects/util-linux
          ENTERED=20010922
-         UPDATED=20160123
+         UPDATED=20160412
            SHORT="Essential utilities for any Linux box"
 
 cat << EOF


### PR DESCRIPTION
enable last and wall. wall is needed to build apsupsd module.