### PR TITLE
cpio: version bumped to 2.12.

### DIFF
--- a/archive/cpio/BUILD
+++ b/archive/cpio/BUILD
@@ -1,15 +1,13 @@
-(
+OPTS+=" --exec-prefix=/usr    \
+        --mandir=/usr/share/man" &&
 
-  # Fixes an incompatibility with glibc-2.16
-  sedit '/gets is a/d' gnu/stdio.in.h &&
-  default_config  &&
-  if module_installed mt-st ; then
-    sedit 's/install:: installdirs all/install:: installdirs/' Makefile  &&
-    make cpio rmt
-  else
-    make
-  fi               &&
-  prepare_install  &&
-  make install
-  
-) > $C_FIFO 2>&1
+OPTS+=" --libexecdir=/usr/bin" &&
+
+default_build &&
+
+# remove the rmt application
+rm -f /usr/bin/rmt &&
+rm -f /usr/share/man/man8/rmt.8 &&
+
+# remove infodir
+rm /usr/share/info/dir

--- a/archive/cpio/DETAILS
+++ b/archive/cpio/DETAILS
@@ -1,16 +1,16 @@
           MODULE=cpio
-         VERSION=2.11
+         VERSION=2.12
           SOURCE=$MODULE-$VERSION.tar.bz2
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.gnu.org/pub/gnu/$MODULE
-      SOURCE_VFY=sha1:6f1934b0079dc1e85ddff89cabdf01adb3a74abb
-        WEB_SITE=http://www.gnu.org/software/cpio/cpio.html
+      SOURCE_VFY=sha256:70998c5816ace8407c8b101c9ba1ffd3ebbecba1f5031046893307580ec1296e
+        WEB_SITE=http://www.gnu.org/software/cpio/
          ENTERED=20011004
-         UPDATED=20100711
-           SHORT="cpio creates cpio archives and have rmt"
+         UPDATED=20160430
+           SHORT="A tool to copy files into or out of a cpio or tar archive"
 
 cat << EOF
 GNU cpio - Creates cpio or tar archives and provides rmt.
 cpio equivalent to tar with a couple of buts and depends.
-this also provides the rmt command.
+It also provides the rmt command.
 EOF

--- a/archive/cpio/POST_REMOVE
+++ b/archive/cpio/POST_REMOVE
@@ -1,1 +1,1 @@
-install-info  --delete cpio  --info-dir /usr/info
+install-info --delete cpio --info-dir /usr/info


### PR DESCRIPTION
Removed the rmt app too. it's not needed anymore as tapes are obsolete now.
