### PR TITLE
openssl: Version bumped to 1.0.2h

### DIFF
--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -1,5 +1,5 @@
           MODULE=openssl
-         VERSION=1.0.2g
+         VERSION=1.0.2h
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=Makefile.openssl-certs
    SOURCE_URL[0]=http://www.openssl.org/source
@@ -8,7 +8,7 @@
    SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
    SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
+      SOURCE_VFY=sha256:1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
      SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
         WEB_SITE=http://www.openssl.org
          ENTERED=20010922


### PR DESCRIPTION
Bug of the month club: there are failures in the AES-NI routines.