### PR TITLE
make: Adding a patch. Ran into this problem with firefox and thunderb…

### DIFF
--- a/devel/make/DETAILS
+++ b/devel/make/DETAILS
@@ -1,12 +1,15 @@
           MODULE=make
          VERSION=4.2
           SOURCE=$MODULE-$VERSION.tar.bz2
+         SOURCE2=make-4.2-fix-double-colon-targets.patch
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.gnu.org/pub/gnu/$MODULE
+     SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha256:4e5ce3b62fe5d75ff8db92b7f6df91e476d10c3aceebf1639796dc5bfece655f
+     SOURCE2_VFY=sha256:a7afc4e264a4a5fcaed6be750486242b518fb81d38f9c094c26d0918442d8772
         WEB_SITE=http://make.paulandlesley.org
          ENTERED=20010922
-         UPDATED=20160523
+         UPDATED=20160607
            SHORT="make generates executables and other non-source programs"
 
 cat << EOF

--- a/devel/make/PRE_BUILD
+++ b/devel/make/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+patch_it $SOURCE2 1


### PR DESCRIPTION
…ird;

nsinstall: cannot access system_wrappers: No such file or directory

There is an issue with make and it's treatment with double colons.

See patch source;

http://git.savannah.gnu.org/cgit/make.git/patch/?id=4762480ae9cb8df4878286411f178d32db14eff0