### PR TITLE
binutils: Something changed with libiberty on this bump. Tulip borks …

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -8,6 +8,7 @@ cd build-binutils &&
              --enable-shared  \
              --enable-threads \
              --enable-gold    \
+             --enable-install-libiberty \
              $OPTS           &&
 
 make tooldir=/usr &&


### PR DESCRIPTION
…when trying to

ld -liberty (can't find it) and was OK with the prior version of binutils. Adding
 --enable-install-libiberty switch fixes the problem. I don't know how this switch
effects things on the whole.