### PR TITLE
nano: The java section was causing;

### DIFF
--- a/editors/nano/DETAILS
+++ b/editors/nano/DETAILS
@@ -1,14 +1,14 @@
           MODULE=nano
          VERSION=2.6.1
           SOURCE=$MODULE-$VERSION.tar.gz
-         SOURCE2=nanorc-20130602.bz2
+         SOURCE2=nanorc-20160704.bz2
       SOURCE_URL=http://www.nano-editor.org/dist/v${VERSION%.*}
      SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha256:56f2ba1c532647bee36abd5f87a714400af0be084cf857a65bc8f41a0dc28fe5
-     SOURCE2_VFY=sha256:f6282a2338c30f6dc87e2b8121ffca3809fe051c1b5ccedfeaa672b6c1b56ca4
+     SOURCE2_VFY=sha256:aa2e5b0b0868d6c275c29e2ced6dd383fc1c6075b78b52d4bbf05a5e6f510e0e
         WEB_SITE=http://www.nano-editor.org
          ENTERED=20010922
-         UPDATED=20160627
+         UPDATED=20160704
            SHORT="Superior clone of the pico text editor"
 
 cat << EOF


### PR DESCRIPTION
Error in /etc/nanorc on line 334: A syntax name must be quoted

It was quoted properly however somethings has changed in the recent nano bumps
and it no longer likes the space existing between "Java source", so replaced it
with a dash.