### PR TITLE
allow to use libressl instead of openssl throughout core

### DIFF
--- a/chat/irssi/DEPENDS
+++ b/chat/irssi/DEPENDS
@@ -2,6 +2,6 @@ depends glib-2
 depends ncurses
 
 optional_depends perl    "--with-perl" "--without-perl" "for perl support"
-optional_depends openssl ""            "--disable-ssl"  "for SSL support"
+optional_depends %OSSL ""            "--disable-ssl"  "for SSL support"
 
 optional_depends perl-libwww "" "" "for scriptassist script"

--- a/crypto/openssh/DEPENDS
+++ b/crypto/openssh/DEPENDS
@@ -1,5 +1,5 @@
 depends zlib
-depends openssl
+depends %OSSL
 depends coreutils
 depends psmisc
 

--- a/ftp/wget/BUILD
+++ b/ftp/wget/BUILD
@@ -1,5 +1,5 @@
 # setting the ssl option
-if in_depends $MODULE openssl; then
+if in_depends $MODULE $(expand_alias %OSSL); then
   OPTS+=" --with-ssl=openssl"
 elif in_depends $MODULE gnutls; then
   OPTS+=" --with-ssl"

--- a/mail/heirloom-mailx/PRE_BUILD
+++ b/mail/heirloom-mailx/PRE_BUILD
@@ -4,4 +4,7 @@ default_pre_build &&
 patch_it $SOURCE2 1 &&
 
 # Removal of SSL3
-patch_it $SOURCE3 1
+patch_it $SOURCE3 1 &&
+
+# support libressl
+sedit "/include <openssl\/rand\.h>/ a #ifdef OPENSSL_NO_EGD\nint RAND_egd(const char* x){return 0;}\n#endif"  openssl.c

--- a/net/iputils/DEPENDS
+++ b/net/iputils/DEPENDS
@@ -1,5 +1,5 @@
 depends libcap
-depends openssl
+depends %OSSL
 depends sysfsutils
 
 optional_depends docbook-utils "" "" "for documentation regeneration"

--- a/wifi/wpa_supplicant/DEPENDS
+++ b/wifi/wpa_supplicant/DEPENDS
@@ -1,4 +1,4 @@
-depends openssl
+depends %OSSL
 depends libnl3
 
 optional_depends dbus "--dbus-yes" "--dbus-no" "for new dbus interface"


### PR DESCRIPTION
This replaces https://github.com/lunar-linux/moonbase-core/pull/1179 .