### PR TITLE
gdisk: new module

### DIFF
--- a/utils/gdisk/BUILD
+++ b/utils/gdisk/BUILD
@@ -1,0 +1,7 @@
+
+make &&
+
+prepare_install &&
+install -m755 {cgdisk,fixparts,gdisk,sgdisk} /usr/sbin &&
+install -m644 {cgdisk,fixparts,gdisk,sgdisk}.8 /usr/share/man/man8
+

--- a/utils/gdisk/DEPENDS
+++ b/utils/gdisk/DEPENDS
@@ -1,0 +1,3 @@
+depends icu4c
+depends ncurses
+depends popt

--- a/utils/gdisk/DETAILS
+++ b/utils/gdisk/DETAILS
@@ -1,0 +1,13 @@
+          MODULE=gdisk
+         VERSION=1.0.1
+          SOURCE=gptfdisk-$VERSION.tar.gz
+		  SOURCE_DIRECTORY=$BUILD_DIRECTORY/gptfdisk-$VERSION
+   SOURCE_URL=https://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/gptfdisk-1.0.1.tar.gz
+   SOURCE_VFY=sha256:864c8aee2efdda50346804d7e6230407d5f42a8ae754df70404dd8b2fdfaeac7
+        WEB_SITE=http://www.rodsbooks.com/gdisk/
+         ENTERED=20161013
+         UPDATED=20161013
+           SHORT="GPT fdisk is a disk partitioning tool loosely modeled on Linux fdisk, but used for modifying GUID Partition Table (GPT) disks."
+cat << EOF
+GPT fdisk (consisting of the gdisk, cgdisk, sgdisk, and fixparts programs) is a set of text-mode partitioning tools for Linux, FreeBSD, Mac OS X, and Windows. The gdisk, cgdisk, and sgdisk programs work on Globally Unique Identifier (GUID) Partition Table (GPT) disks, rather than on the more common (through at least early 2013) Master Boot Record (MBR) partition tables. The fixparts program repairs certain types of damage to MBR disks and enables changing partition types from primary to logical and vice-versa.
+EOF


### PR DESCRIPTION
http://www.rodsbooks.com/gdisk/
https://sourceforge.net/projects/gptfdisk/files/gptfdisk/1.0.1/
GPT fdisk (consisting of the gdisk, cgdisk, sgdisk, and fixparts programs) is a set of text-mode partitioning tools for Linux, FreeBSD, Mac OS X, and Windows. The gdisk, cgdisk, and sgdisk programs work on Globally Unique Identifier (GUID) Partition Table (GPT) disks, rather than on the more common (through at least early 2013) Master Boot Record (MBR) partition tables. The fixparts program repairs certain types of damage to MBR disks and enables changing partition types from primary to logical and vice-versa.