### PR TITLE
glib-2: version bumped to 2.51.0 (required by gvfs)

### DIFF
--- a/libs/glib-2/DETAILS
+++ b/libs/glib-2/DETAILS
@@ -1,16 +1,16 @@
           MODULE=glib-2
-         VERSION=50.2
+         VERSION=51.0
           SOURCE=$MODULE.$VERSION.tar.xz
          SOURCE2=glib-2.50.x-external-gdbus-codegen.patch
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE.$VERSION
    SOURCE_URL[0]=$GNOME_URL/sources/glib/${MODULE#*-}.${VERSION%.*}
    SOURCE_URL[1]=http://ftp.gtk.org/pub/glib/${MODULE#*-}.${VERSION%.*}
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:be68737c1f268c05493e503b3b654d2b7f43d7d0b8c5556f7e4651b870acfbf5
+      SOURCE_VFY=sha256:f113b7330f4b4a43e3e401fe7849e751831060d574bd936a63e979887137a74a
      SOURCE2_VFY=sha256:983da47da96897df63fef7159408403e1a8c391a15b08d6d1b1226a442f636b6
         WEB_SITE=http://library.gnome.org/devel/glib
          ENTERED=20020313
-         UPDATED=20161107
+         UPDATED=20161216
            SHORT="A library of useful C routines for trees, hashes, and lists"
 
 cat << EOF


### PR DESCRIPTION
the gvfs configure fails, requiring >= glib-2.51.0