### PR TITLE
ca-certificates: version bumped to 20161130

### DIFF
--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,12 +1,12 @@
           MODULE=ca-certificates
-         VERSION=20161102
+         VERSION=20161130
           SOURCE=${MODULE}_$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE
       SOURCE_URL=ftp://ftp.debian.org/debian/pool/main/c/$MODULE/
-      SOURCE_VFY=sha256:25384a67e2f1e76495ceeb00abfdbe831033780324128cb1587d09132dd173a5
+      SOURCE_VFY=sha256:04bca9e142a90a834aca0311f7ced237368d71fee7bd5c9f68ef7f4611aee471
         WEB_SITE=http://packages.qa.debian.org/c/ca-certificates.html
          ENTERED=20100405
-         UPDATED=20161115
+         UPDATED=20170110
            SHORT="Common CA certificates"
 
 cat << EOF


### PR DESCRIPTION
the previous archive is not on the host site anymore nor on Lunar's mirror