### PR TITLE
dialog: fixed a missing configure option

### DIFF
--- a/utils/dialog/BUILD
+++ b/utils/dialog/BUILD
@@ -1,3 +1,3 @@
-OPTS+=" --with-shared" &&
+OPTS+=" --with-ncurses --with-shared" &&
 
 default_build


### PR DESCRIPTION
the message was "configure: error: no curses library found"