### PR TITLE
binutils: enable -plugin for ld.gold

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -10,6 +10,7 @@ CFLAGS+=" -fPIC" &&
              --enable-shared  \
              --enable-threads \
              --enable-gold    \
+             --enable-plugins \
              --enable-install-libiberty \
              $OPTS           &&
 

--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -6,7 +6,7 @@
       SOURCE_VFY=sha256:cd717966fc761d840d451dbd58d44e1e5b92949d2073d75b73fccb476d772fcf
         WEB_SITE=http://sources.redhat.com/binutils
          ENTERED=20010922
-         UPDATED=20170309
+         UPDATED=20170328
            SHORT="An essential collection of binary utilities"
 
 cat << EOF


### PR DESCRIPTION
Without this option `gcc -fuse-ld=gold` (as used e.g. by blender)
will fail because gcc forwards plugin options to the linker.