### PR TITLE
make: Fix the situation where make itself is broken.

### DIFF
--- a/devel/make/BUILD
+++ b/devel/make/BUILD
@@ -1,0 +1,11 @@
+default_config &&
+
+if ! make ${MAKES:-j${MAKES}} 
+then
+    ./build.sh &&
+    prepare_install &&
+    ./make install
+else
+    prepare_install &&
+    make install
+fi


### PR DESCRIPTION
The latest guile update broke my make executable.  This led to an
awkward situation.

Since make can bootstrap itself, this checks to see if make itself fell
over while trying to build itself, and uses the bootstrap script to
rescue itself.