### PR TITLE
lzip: Move lzip from moonbase-other to moonbase-core.

### DIFF
--- a/archive/lzip/BUILD
+++ b/archive/lzip/BUILD
@@ -1,0 +1,9 @@
+
+./configure --prefix=/usr              \
+            --infodir=/usr/share/info  \
+            --mandir=/usr/share/man    \
+            $OPTS                     &&
+
+make &&
+prepare_install &&
+make install-strip

--- a/archive/lzip/DETAILS
+++ b/archive/lzip/DETAILS
@@ -1,0 +1,17 @@
+          MODULE=lzip
+         VERSION=1.19
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=http://download.savannah.gnu.org/releases/lzip
+      SOURCE_VFY=sha256:ffadc4f56be1bc0d3ae155ec4527bd003133bdc703a753b2cc683f610e646ba9
+        WEB_SITE=http://nongnu.askapache.com/lzip/manual/lzip_manual.html
+         ENTERED=20091122
+         UPDATED=20170501
+           SHORT="lossless data compressor"
+
+cat << EOF
+Lzip is a lossless data compressor based on the LZMA algorithm, with
+very safe integrity checking and a user interface similar to the one of
+gzip or bzip2. Lzip decompresses almost as fast as gzip and compresses
+better than bzip2, which makes it well suited for software distribution
+and data archiving.
+EOF

--- a/archive/lzip/PRE_BUILD
+++ b/archive/lzip/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+sedit "s/^CPPFLAGS=/\0\${CPPFLAGS}/;
+       s/^CXXFLAGS=\(.*\)$/CXXFLAGS=\${CXXFLAGS:-\1}/;
+       s/^LDFLAGS=/\0\${LDFLAGS}/" configure

--- a/archive/lzip/plugin.d/unpack-lzip.plugin
+++ b/archive/lzip/plugin.d/unpack-lzip.plugin
@@ -1,0 +1,30 @@
+#!/bin/bash
+####################################################################
+#                                                                  #
+# unpack-lzip.plugin - unpacks tar.lz and lz files                 #
+#                                                                  #
+####################################################################
+#                                                                  #
+# Copyright 2015 Stefan Wold <ratler@lunar-linux.org> under GPLv2  #
+#                                                                  #
+####################################################################
+
+plugin_unpack_lzip() {
+  case $1 in
+    *.tar.lz)
+      debug_msg "Unpacking tar file ($1)"
+      tar xf $1 --no-same-owner --no-same-permissions || return 1
+      ;;
+    *.lz)
+      debug_msg "Unpacking lzip file ($1)"
+      cp $1 . || return 1
+      lzip -d $1 || return 1
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+  return 0
+}
+
+plugin_register SOURCE_UNPACK plugin_unpack_lzip


### PR DESCRIPTION
Some GNU projects in moonbase-core (like ed) have switched from using
gzip to lzip to compress their tarballs, so I think lzip now also needs
to be in moonbase-core.