### PR TITLE
installwatch: added support for symlinkat()

### DIFF
--- a/utils/installwatch/BUILD
+++ b/utils/installwatch/BUILD
@@ -1,14 +1,8 @@
-(
+sedit  "s:PREFIX=/usr/local:PREFIX=/usr:"  Makefile &&
+sedit  "s/gcc /gcc $CFLAGS /"              Makefile &&
 
-  patch_it $SOURCE_CACHE/$SOURCE2 1  &&
+default_make &&
 
-  sedit  "s:PREFIX=/usr/local:PREFIX=/usr:"  Makefile &&
-  sedit  "s/gcc /gcc $CFLAGS /"              Makefile &&
-
-  default_make &&
-
-  # since the installwatch module cannot track itself when it's
-  # overwritten we need to assure it goes in the log/cache:
-  touch /usr/lib/installwatch.so
-
-) > $C_FIFO 2>&1
+# since the installwatch module cannot track itself when it's
+# overwritten we need to assure it goes in the log/cache:
+ touch /usr/lib/installwatch.so

--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -2,14 +2,17 @@
          VERSION=0.6.3
           SOURCE=$MODULE-$VERSION.tgz
          SOURCE2=$MODULE-$VERSION-at_support_realpathfix6.patch.gz
+         SOURCE3=$MODULE-$VERSION-atsymlink_support.patch
    SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
    SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha1:e6090aaae6e6df8af11913efa4eb056d0ac07ade
-     SOURCE2_VFY=sha1:357b8a204f6f51840d0dbc906dd176ab1321d86f
+     SOURCE3_URL=$PATCH_URL
+      SOURCE_VFY=sha256:0d02e5e625c15bf0ffca1d53108902b29d9e80dadc62dc648e6bfd229d63fdec
+     SOURCE2_VFY=sha256:0a054f633a522cbfb8e761a34a36adb7f254815ad59cdb94c83d33b15c97b51a
+     SOURCE3_VFY=sha256:abd208dba41248f26c7eb4d376f6f88ec06f76d36cae334b799a1e4524585632
         WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
          ENTERED=20011230
-         UPDATED=20130606
+         UPDATED=20170715
       MAINTAINER=v4hn@lunar-linux.org
            SHORT="utility for tracking files from installation of software"
 

--- a/utils/installwatch/PRE_BUILD
+++ b/utils/installwatch/PRE_BUILD
@@ -2,18 +2,20 @@ if  [  -u  /usr/bin/make  ]   ||
     [  -g  /usr/bin/make  ];  then
   message  "A non setuid/gid /usr/bin/make is required."
   lin  -c  make
-fi
+fi &&
 
 
-if  !  ldd  /bin/tar  >  /dev/null;  then
-  message  "A dynamically linked /bin/tar is required."
+if  !  ldd  /usr/bin/tar  >  /dev/null;  then
+  message  "A dynamically linked /usr/bin/tar is required."
   lin  -c  tar
-fi
+fi &&
 
 
 if  !  ldd  /usr/bin/bzip2  >  /dev/null;  then
   message  "A dynamically linked /usr/bin/bzip2 is required."
   lin  -c  bzip2
-fi
+fi &&
 
-default_pre_build
+default_pre_build &&
+patch_it $SOURCE2 1 &&
+patch_it $SOURCE3 1


### PR DESCRIPTION
'ln' in coreutils is now using symlinkat() over symlink() which
resulted in missing symlinks in the cache tarballs.