### PR TITLE
lvm2: re-enable %UDEV dependency

### DIFF
--- a/filesys/lvm2/DEPENDS
+++ b/filesys/lvm2/DEPENDS
@@ -1,5 +1,5 @@
 depends readline
 depends pkgconfig
 
-# circular depend with systemd
-#depends %UDEV
+# optional circular depend with systemd->cryptsetup
+depends %UDEV


### PR DESCRIPTION
The circular dependency comes from the optional dependency
on cryptsetup. Thus we don't need to comment this out and
it actually breaks the iso building process.

@dagbrown inspired from one of your commits in your iso pull-request.