### PR TITLE
Python: Baby steps to make it not the default python.

### DIFF
--- a/python/Python/BUILD
+++ b/python/Python/BUILD
@@ -7,6 +7,8 @@ make &&
 prepare_install &&
 make altinstall &&
 
+test -L /usr/bin/python || ln -s /usr/bin/python${VERSION%.*} /usr/bin/python &&
+
 install -d /usr/lib/python${VERSION%.*} &&
 install -m755 $SOURCE_DIRECTORY/Tools/i18n/msgfmt.py \
               $SOURCE_DIRECTORY/Tools/i18n/pygettext.py \

--- a/python/Python/BUILD
+++ b/python/Python/BUILD
@@ -1,6 +1,11 @@
 OPTS+=" --enable-shared" &&
 
-default_build &&
+default_config &&
+
+# This is important, lets 3.x versions and it to coexist.
+make &&
+prepare_install &&
+make altinstall &&
 
 install -d /usr/lib/python${VERSION%.*} &&
 install -m755 $SOURCE_DIRECTORY/Tools/i18n/msgfmt.py \


### PR DESCRIPTION
This installs it using the "altinstall" install method, which doesn't
install Python as "/usr/bin/python", but as "/usr/bin/python2.7".