### PR TITLE
wget: SSL support is no longer an optional thing.

### DIFF
--- a/ftp/wget/DEPENDS
+++ b/ftp/wget/DEPENDS
@@ -1,4 +1,4 @@
-depends %SSL "" "" "for SSL support"
+depends %SSL
 
 optional_depends gettext "--enable-nls" "--disable-nls" "for NLS support"
 optional_depends libidn  "--enable-iri" "--disable-iri" "for IDN/IRIs support"

--- a/ftp/wget/DEPENDS
+++ b/ftp/wget/DEPENDS
@@ -1,4 +1,4 @@
-optional_depends %SSL "" "" "for SSL support"
+depends %SSL "" "" "for SSL support"
 
 optional_depends gettext "--enable-nls" "--disable-nls" "for NLS support"
 optional_depends libidn  "--enable-iri" "--disable-iri" "for IDN/IRIs support"


### PR DESCRIPTION
Now that pciutils and other low-level stuff is only available via https,
we can no longer consider SSL to be an optional dependency for wget.

(pciutils broke the ISO build!)