### PR TITLE
installwatch: patch to initialized if called uninitialized

### DIFF
--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -3,16 +3,19 @@
           SOURCE=$MODULE-$VERSION.tgz
          SOURCE2=$MODULE-$VERSION-at_support_realpathfix6.patch.gz
          SOURCE3=$MODULE-$VERSION-symlinkat_support.patch
+         SOURCE4=$MODULE-$VERSION-init_support.patch.gz
    SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
    SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
      SOURCE2_URL=$PATCH_URL
      SOURCE3_URL=$PATCH_URL
+     SOURCE4_URL=$PATCH_URL
       SOURCE_VFY=sha256:0d02e5e625c15bf0ffca1d53108902b29d9e80dadc62dc648e6bfd229d63fdec
      SOURCE2_VFY=sha256:0a054f633a522cbfb8e761a34a36adb7f254815ad59cdb94c83d33b15c97b51a
      SOURCE3_VFY=sha256:26434c3801279097ec86d1d8fe47a3482ff266b4d0a3a855d345a4802803d616
+     SOURCE4_VFY=sha256:d156911b09cea1cafd111a2bfeeb504b880555eadb294c68a85446516f3fc050
         WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
          ENTERED=20011230
-         UPDATED=20170715
+         UPDATED=20171218
       MAINTAINER=v4hn@lunar-linux.org
            SHORT="utility for tracking files from installation of software"
 

--- a/utils/installwatch/PRE_BUILD
+++ b/utils/installwatch/PRE_BUILD
@@ -18,4 +18,5 @@ fi &&
 
 default_pre_build &&
 patch_it $SOURCE2 1 &&
-patch_it $SOURCE3 1
+patch_it $SOURCE3 1 &&
+patch_it $SOURCE4 1


### PR DESCRIPTION
ld's initialization behavior for shared objects is a mess.
The order is pretty much arbitrary. In theory one can mark a library as
"initfirst" to avoid other shared objects initializing before,
but that's a *unique* mark and libpthread uses it already.

As a result LD_PRELOAD overlays the libc methods *from start*,
but until libinstallwatch is initialized (_init called),
libs end up calling invalid function pointers if they access an
overlayed libc method.

To fix this within installwatch, we have to check for successful
initialization in *each* method call...

Frustratingly, the llvm version of the latest rustc tries to access
the number of cores `open("/proc/cpuinfo")` during library initialization
(WHYYY?!) and thus segfaults if ld decides to load it before libinstallwatch.

And all I was trying to do is getting a new firefox version compiled...