### PR TITLE
perl: Just an UPDATED change to kick off a rebuild on lunadroid. Sinc…

### DIFF
--- a/perl/perl/DETAILS
+++ b/perl/perl/DETAILS
@@ -7,7 +7,7 @@
       SOURCE_VFY=sha256:e763aa485e8dc1a70483dbe6d615986bbf32b977f38016480d68c99237e701dd
         WEB_SITE=http://www.perl.org
          ENTERED=20010922
-         UPDATED=20170927
+         UPDATED=20171224
            SHORT="A highly capable, feature-rich programming language"
 
 cat << EOF


### PR DESCRIPTION
…e the glibc bump xlocale.h was removed

leaving only locale.h. As such some apps will tank unless perl is rebuilt. You will see this kind of error;

 /usr/lib/perl5/5.26.1/x86_64-linux-thread-multi/CORE/perl.h:738:13: fatal error: xlocale.h: No such file or directory