### PR TITLE
gcc: Version bump to 7.3.0

### DIFF
--- a/compilers/gcc/DETAILS
+++ b/compilers/gcc/DETAILS
@@ -1,13 +1,13 @@
           MODULE=gcc
-         VERSION=7.2.0
+         VERSION=7.3.0
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$GNU_URL/gcc/$MODULE-$VERSION/
    SOURCE_URL[1]=ftp://gcc.gnu.org/pub/gcc/releases/gcc-$VERSION/
    SOURCE_URL[2]=http://www.online-mirror.org/gcc/$MODULE-$VERSION/
-      SOURCE_VFY=sha256:1cf7adf8ff4b5aa49041c8734bbcf1ad18cc4c94d0029aae0f4e48841088479a
+      SOURCE_VFY=sha256:832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c
         WEB_SITE=http://gcc.gnu.org/
          ENTERED=20020628
-         UPDATED=20170815
+         UPDATED=20180126
            SHORT="GNU compiler collection"
 
 cat << EOF

--- a/compilers/gcc/plugin.d/optimize-gcc_7_2.plugin
+++ b/compilers/gcc/plugin.d/optimize-gcc_7_2.plugin
@@ -1,5 +1,5 @@
 #
-# gcc-7.2.x compiler optimizations plugin
+# gcc-7.3.x compiler optimizations plugin
 #
 
 compiler_gcc_optimize_defaults()
@@ -10,18 +10,18 @@ compiler_gcc_optimize_defaults()
   CPU=$(arch | sed 's;_;-;')
 }
 
-plugin_compiler_gcc_7_2_optimize()
+plugin_compiler_gcc_7_3_optimize()
 {
-  if [ "${LUNAR_COMPILER:-GCC_7_2}" != "GCC_7_2" ]; then
+  if [ "${LUNAR_COMPILER:-GCC_7_3}" != "GCC_7_3" ]; then
     return 2
   fi
 
-  debug_msg "plugin_compiler_gcc_7_2_optimize($@)"
+  debug_msg "plugin_compiler_gcc_7_3_optimize($@)"
 
   compiler_gcc_optimize_defaults
 
-  if [ -f /etc/lunar/local/optimizations.GCC_7_2 ]; then
-    . /etc/lunar/local/optimizations.GCC_7_2
+  if [ -f /etc/lunar/local/optimizations.GCC_7_3 ]; then
+    . /etc/lunar/local/optimizations.GCC_7_3
   fi
 
   # some local macro's
@@ -170,17 +170,17 @@ plugin_compiler_gcc_7_2_optimize()
 }
 
 
-plugin_compiler_gcc_7_2_menu()
+plugin_compiler_gcc_7_3_menu()
 {
   # The main code calls this function WITHOUT $1 to find out which
   # compiler optimization plugins exist. It then returns the plugin
   # identifier which can be saved in $LUNAR_COMPILER as the user's
   # choice for COMPILERS
   if [ -z "$1" ]; then
-    echo "GCC_7_2"
+    echo "GCC_7_3"
     echo "GNU C Compiler suite version 7.2.x"
     return 2
-  elif [ "$1" != "GCC_7_2" ]; then
+  elif [ "$1" != "GCC_7_3" ]; then
     # we don't display anything when the user selected a
     # different menu
     return 2
@@ -209,7 +209,7 @@ plugin_compiler_gcc_7_2_menu()
   save_optimizations()
   {
     debug_msg "save_optimizations($@)"
-    cat >/etc/lunar/local/optimizations.GCC_7_2  <<EOF
+    cat >/etc/lunar/local/optimizations.GCC_7_3  <<EOF
 CPU=$CPU
 CPUTUNE=$CPUTUNE
 BOPT=$BOPT
@@ -223,8 +223,8 @@ EOF
 
   compiler_gcc_optimize_defaults
 
-  if [ -f /etc/lunar/local/optimizations.GCC_7_2 ]; then
-    . /etc/lunar/local/optimizations.GCC_7_2
+  if [ -f /etc/lunar/local/optimizations.GCC_7_3 ]; then
+    . /etc/lunar/local/optimizations.GCC_7_3
   fi
 
   export IFS=$'\t\n'
@@ -234,7 +234,7 @@ EOF
 
   while true; do
     unset OPTIONS
-    IS_DEFAULT=$([ "$(get_local_config LUNAR_COMPILER)" == "GCC_7_2" ] && echo DEFAULT || get_local_config LUNAR_COMPILER)
+    IS_DEFAULT=$([ "$(get_local_config LUNAR_COMPILER)" == "GCC_7_3" ] && echo DEFAULT || get_local_config LUNAR_COMPILER)
     DEFAULT=${CHOICE:-safe}
     CHOICE=`$DIALOG --title "$TITLE" --ok-label "Select" --cancel-label "Close" --default-item "$DEFAULT" --item-help --menu "" 0 0 0 $(
       echo "default"
@@ -286,7 +286,7 @@ EOF
       case $CHOICE in
         default)
           if [ "$IS_DEFAULT" != "DEFAULT" ]; then
-            set_local_config LUNAR_COMPILER GCC_7_2
+            set_local_config LUNAR_COMPILER GCC_7_3
             $DIALOG --msgbox "Gcc 7.2 is now the default compiler!" 6 60
           fi
           ;;
@@ -678,5 +678,5 @@ EOF
 }
 
 
-plugin_register BUILD_BUILD plugin_compiler_gcc_7_2_optimize
-plugin_register OPTIMIZE_MENU plugin_compiler_gcc_7_2_menu
+plugin_register BUILD_BUILD plugin_compiler_gcc_7_3_optimize
+plugin_register OPTIMIZE_MENU plugin_compiler_gcc_7_3_menu


### PR DESCRIPTION
Apparently it comes with SPECTRE v2 mitigation.  Otherwise it's just bug
fixes for gcc 7.2.0.