### PR TITLE
vim without GUI should not link X

### DIFF
--- a/editors/vim/BUILD
+++ b/editors/vim/BUILD
@@ -3,6 +3,12 @@ OPTS+=" --disable-perlinterp --disable-luainterp --disable-rubyinterp" &&
 
 OPTS+=" --with-features=huge --enable-cscope --enable-fail-if-missing" &&
 
+# otherwise it defaults to auto/x+gtk
+if ! in_depends $MODULE gtk+-3 && ! in_depends $MODULE gtk+-2; then
+  OPTS+=" --enable-gui=no --without-x"
+fi &&
+
+
 cd src &&
 
 default_config &&

--- a/editors/vim/DETAILS
+++ b/editors/vim/DETAILS
@@ -20,7 +20,7 @@
          WEB_SITE=http://vim.sf.net
        MAINTAINER=sofar@lunar-linux.org
           ENTERED=20010922
-          UPDATED=20161111
+          UPDATED=20180303
             SHORT="Improved version of vi"
 
 cat << EOF


### PR DESCRIPTION
I was wondering the other day why my vim linked libx*
when I deactivated all GUI backends.
This change fixes it.