### PR TITLE
make: Really stupid fix to a really stupid problem.

### DIFF
--- a/devel/make/PRE_BUILD
+++ b/devel/make/PRE_BUILD
@@ -4,4 +4,6 @@ default_pre_build &&
 sedit 's|guile-1.8|guile-2.2|g' configure.ac &&
 
 # work around an error caused by glibc-2.27
-sedit '211,217 d; 219,229 d; 232 d' glob/glob.c
+sedit '211,217 d; 219,229 d; 232 d' glob/glob.c &&
+
+autoreconf -fi


### PR DESCRIPTION
GNU make fails to build because as part of its build process, for some
reason it insists on doing another round of autoconf/automake.  Thing
is, the version of automake they use is hard-coded into their build, and
since they made their package, a new release of automake has come out.

So this disgusting hack just finds all mentions of the hardcoded
automake and aclocal versions, and updates them to refer to whatever
version of automake is actually installed.

This hack should be temporary, but while the make package depends on
automake 1.15, the daily ISO build is failing.