### PR TITLE
Perl modules: use module type instead of BUILD file

### DIFF
--- a/perl/TimeDate/BUILD
+++ b/perl/TimeDate/BUILD
@@ -1,3 +1,0 @@
-
-  perl  Makefile.PL  &&
-  default_make

--- a/perl/TimeDate/DETAILS
+++ b/perl/TimeDate/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/G/GB/GBARR/
       SOURCE_VFY=sha256:75bd254871cb5853a6aa0403ac0be270cdd75c9d1b6639f18ecba63c15298e86
         WEB_SITE=http://search.cpan.org/~gbarr/TimeDate/
+            TYPE=perl
          ENTERED=20021228
          UPDATED=20150705
            SHORT="Convert date strings into time format"

--- a/perl/URI/BUILD
+++ b/perl/URI/BUILD
@@ -1,3 +1,0 @@
-perl  Makefile.PL &&
-
-default_make

--- a/perl/URI/DETAILS
+++ b/perl/URI/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/E/ET/ETHER
       SOURCE_VFY=sha256:cca7ab4a6f63f3ccaacae0f2e1337e8edf84137e73f18548ec7d659f23efe413
         WEB_SITE=http://search.cpan.org/dist/URI/
+            TYPE=perl
          ENTERED=20020727
          UPDATED=20180109
            SHORT="A perl module for using Uniform Resource Identifiers"

--- a/perl/XML-Parser/BUILD
+++ b/perl/XML-Parser/BUILD
@@ -1,6 +1,0 @@
-(
-
-  perl  Makefile.PL  &&
-  default_make
-
-) > $C_FIFO 2>&1

--- a/perl/XML-Parser/DETAILS
+++ b/perl/XML-Parser/DETAILS
@@ -4,6 +4,7 @@
       SOURCE_URL=http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/
       SOURCE_VFY=sha256:1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216
         WEB_SITE=http://search.cpan.org/search?dist=XML-Parser
+            TYPE=perl
          ENTERED=20030529
          UPDATED=20150405
            SHORT="PERL module for parsing XML documents"


### PR DESCRIPTION
Note: This is for testing only.  Do not merge until the next release of the `lunar` utility, which allows you to specify a module type to use a common build method, instead of having to put the same BUILD file in every similar module.