### PR TITLE
btrfs-progs: Make Python 3 an optional dependency.

### DIFF
--- a/filesys/btrfs-progs/DEPENDS
+++ b/filesys/btrfs-progs/DEPENDS
@@ -2,7 +2,9 @@ depends zlib
 depends lzo
 depends e2fsprogs
 
-optional_depends zstd "" "--disable-zstd" "fot zstd compression support" n
+optional_depends zstd "" "--disable-zstd" "for zstd compression support" n
+optional_depends python3 "--enable-python" "--disable-python" \
+    "to build libbtrfsutil Python bindings"
 
 optional_depends xmlto    "" "" "for documentation (also requires asciidoc)" n
 optional_depends asciidoc "" "" "for documentation (also requires xmlto)" n


### PR DESCRIPTION
If you tell it not to build the Python 3 interface, it won't.  But
it defaults to assuming that you do want Python 3 support, and
fails hard if Python 3 isn't installed.  So make it not do that.