### PR TITLE
util-linux: Fixing the Python dependency.

### DIFF
--- a/utils/util-linux/DEPENDS
+++ b/utils/util-linux/DEPENDS
@@ -2,7 +2,7 @@ depends ncurses
 depends shadow
 depends zlib
 
-optional_depends Python-3 "--with-python=3" "" "for Python support" y
-optional_depends Python   "--with-python=2" "" "for Python2 support" n
+optional_depends Python-3 "--with-python=3" "" "for Python support" n
+optional_depends Python   "--with-python=2" "" "for Python2 support" y
 
 optional_depends Linux-PAM "" "" "for PAM support"


### PR DESCRIPTION
Making a default dependency on something outside of moonbase-core
will BREAK THE DAILY ISO BUILD.  Please do NOT do that.

Yes, Python-3 will eventually become the default Python.  But stop
breaking stuff in the name of attempting to force Python-3 in
where it's not welcome yet.