### PR TITLE
iputils: version bumped to s20180629.

### DIFF
--- a/libs/libidn2/BUILD
+++ b/libs/libidn2/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-gtk-doc"
+
+default_build

--- a/libs/libidn2/DEPENDS
+++ b/libs/libidn2/DEPENDS
@@ -1,0 +1,7 @@
+depends libunistring
+
+# broken
+#optional_depends gtk-doc \
+#                 "--enable-gtk-doc" \
+#                 "--disable-gtk-doc" \
+#                 "for building documentation"

--- a/libs/libidn2/DETAILS
+++ b/libs/libidn2/DETAILS
@@ -1,0 +1,15 @@
+          MODULE=libidn2
+         VERSION=2.0.5
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=https://ftp.gnu.org/gnu/libidn/
+      SOURCE_VFY=sha256:53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8
+        WEB_SITE=https://www.gnu.org/software/libidn/#libidn2
+         ENTERED=20180314
+         UPDATED=20180519
+           SHORT="An implementation of IDNA2008, Punycode and TR46"
+
+cat << EOF
+Libidn2 is a standalone library, without any dependency on Libidn. Libidn2 is
+believed to be a complete IDNA2008 / TR46 implementation, but has yet to be as
+extensively used as the original Libidn library.
+EOF

--- a/libs/libidn2/PRE_BUILD
+++ b/libs/libidn2/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+autoreconf -fvi

--- a/libs/libunistring/DETAILS
+++ b/libs/libunistring/DETAILS
@@ -1,0 +1,41 @@
+          MODULE=libunistring
+         VERSION=0.9.10
+          SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE_URL=http://ftp.gnu.org/gnu/$MODULE
+      SOURCE_VFY=sha256:a82e5b333339a88ea4608e4635479a1cfb2e01aafb925e1290b65710d43f610b
+        WEB_SITE=http://www.gnu.org/software/libunistring
+         ENTERED=20120711
+         UPDATED=20180601
+           SHORT="A library for manipulating Unicode strings and C strings"
+
+cat << EOF
+This library provides functions for manipulating Unicode strings and
+for manipulating C strings according to the Unicode standard.
+
+It consists of the following parts:
+
+  unistr.h     elementary string functions
+  uniconv.h    conversion from/to legacy encodings
+  unistdio.h   formatted output to strings
+  uniname.h    character names
+  unictype.h   character classification and properties
+  uniwidth.h   string width when using nonproportional fonts
+  uniwbrk.h    word breaks
+  unilbrk.h    line breaking algorithm
+  uninorm.h    normalization (composition and decomposition)
+  unicase.h    case folding
+  uniregex.h   regular expressions (not yet implemented)
+
+libunistring is for you if your application involves non-trivial text
+processing, such as upper/lower case conversions, line breaking, operations
+on words, or more advanced analysis of text. Text provided by the user can,
+in general, contain characters of all kinds of scripts. The text processing
+functions provided by this library handle all scripts and all languages.
+
+libunistring is for you if your application already uses the ISO C / POSIX
+<ctype.h>, <wctype.h> functions and the text it operates on is provided by
+the user and can be in any language.
+
+libunistring is also for you if your application uses Unicode strings as
+internal in-memory representation.
+EOF

--- a/net/iputils/DEPENDS
+++ b/net/iputils/DEPENDS
@@ -1,5 +1,6 @@
 depends libcap
-depends libidn
+depends libidn2
+depends libmnl
 depends %OSSL
 depends sysfsutils
 

--- a/net/iputils/DETAILS
+++ b/net/iputils/DETAILS
@@ -1,14 +1,14 @@
           MODULE=iputils
-         VERSION=s20161105
+         VERSION=s20180629
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=$MODULE-$VERSION-manpages.tar.gz
  SOURCE_URL_FULL=http://github.com/iputils/iputils/archive/$VERSION.tar.gz
      SOURCE2_URL=$PATCH_URL
         WEB_SITE=http://github.com/iputils/iputils/
-      SOURCE_VFY=sha256:f813092f03d17294fd23544b129b95cdb87fe19f7970a51908a6b88509acad8a
-     SOURCE2_VFY=sha256:23d9ab10157c46373751bd36b19468f03eb52d9d828927d9d603f4b19a7e7d44
+      SOURCE_VFY=sha256:da14105291dd491f28ea91ade854ed10aee8ba019641c80eed233de3908be7c5
+     SOURCE2_VFY=sha256:62ca4fa09a7d5196803269fe98bcd29339d8a5b3e688e6dd04bc1b1112ee0536
          ENTERED=20021106
-         UPDATED=20161127
+         UPDATED=20180712
            SHORT="Essential utilities for IP networks"
 
 cat << EOF


### PR DESCRIPTION
It depends on libid2 which needs libunistring.

