### PR TITLE
installwatch: lunars own fork, version 0.8.0rc2

### DIFF
--- a/utils/installwatch/BUILD
+++ b/utils/installwatch/BUILD
@@ -1,8 +1,6 @@
-sedit  "s:PREFIX=/usr/local:PREFIX=/usr:"  Makefile &&
-sedit  "s/gcc /gcc $CFLAGS /"              Makefile &&
-
-default_make &&
-
-# since the installwatch module cannot track itself when it's
-# overwritten we need to assure it goes in the log/cache:
- touch /usr/lib/installwatch.so
+OPTS+=" --disable-access-syscall --disable-acl-syscall"
+default_config &&
+make &&
+make check &&
+prepare_install &&
+make install

--- a/utils/installwatch/DETAILS
+++ b/utils/installwatch/DETAILS
@@ -1,22 +1,11 @@
           MODULE=installwatch
-         VERSION=0.6.3
-          SOURCE=$MODULE-$VERSION.tgz
-         SOURCE2=$MODULE-$VERSION-at_support_realpathfix6.patch.gz
-         SOURCE3=$MODULE-$VERSION-symlinkat_support.patch
-         SOURCE4=$MODULE-$VERSION-init_support.patch.gz
-   SOURCE_URL[0]=http://download.lunar-linux.org/lunar/mirrors
-   SOURCE_URL[1]=http://asic-linux.com.mx/~izto/checkinstall/files/source
-     SOURCE2_URL=$PATCH_URL
-     SOURCE3_URL=$PATCH_URL
-     SOURCE4_URL=$PATCH_URL
-      SOURCE_VFY=sha256:0d02e5e625c15bf0ffca1d53108902b29d9e80dadc62dc648e6bfd229d63fdec
-     SOURCE2_VFY=sha256:0a054f633a522cbfb8e761a34a36adb7f254815ad59cdb94c83d33b15c97b51a
-     SOURCE3_VFY=sha256:26434c3801279097ec86d1d8fe47a3482ff266b4d0a3a855d345a4802803d616
-     SOURCE4_VFY=sha256:d156911b09cea1cafd111a2bfeeb504b880555eadb294c68a85446516f3fc050
-        WEB_SITE=http://asic-linux.com.mx/~izto/checkinstall/installwatch.html
+         VERSION=0.8.0rc2
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/lunar-linux/installwatch/releases/download/v$VERSION
+      SOURCE_VFY=sha256:ef949ba38d32d2586d41e8f1f6cb2838ab2af8697e16426704018adfb7637c8a
+        WEB_SITE=https://github.com/lunar-linux/installwatch
          ENTERED=20011230
-         UPDATED=20171218
-      MAINTAINER=v4hn@lunar-linux.org
+         UPDATED=20180720
            SHORT="utility for tracking files from installation of software"
 
 cat << EOF

--- a/utils/installwatch/PRE_BUILD
+++ b/utils/installwatch/PRE_BUILD
@@ -16,7 +16,4 @@ if  !  ldd  /usr/bin/bzip2  >  /dev/null;  then
   lin  -c  bzip2
 fi &&
 
-default_pre_build &&
-patch_it $SOURCE2 1 &&
-patch_it $SOURCE3 1 &&
-patch_it $SOURCE4 1
+default_pre_build


### PR DESCRIPTION
Adds a bunch of missing syscalls compared to our old version of installwatch.
This update is required Due to recent changes in coreutils where they switched
to newer *at syscalls which caused installwatch in lunar to miss a lot of files.

This update should remedy that.