### PR TITLE
util-linux: Fix Python dependencies.

### DIFF
--- a/utils/util-linux/DEPENDS
+++ b/utils/util-linux/DEPENDS
@@ -4,7 +4,7 @@ depends zlib
 depends findutils
 depends cpio
 
-optional_depends python  "--with-python=3" "" "for Python 3 support" n
-optional_depends python2 "--with-python=2" "" "for Python 2 support" y
+optional_depends python  "--with-python=3" "" "for Python 3 support" y
+optional_depends python2 "--with-python=2" "" "for Python 2 support" n
 
 optional_depends Linux-PAM "" "" "for PAM support"


### PR DESCRIPTION
Now that the default version of Python is 3, default to saying
"no" for the optional dependency on Python 2, and "yes" for Python
3.