### PR TITLE
Linux: Version bump to 4.18.5.

### DIFF
--- a/kernel/linux/DETAILS
+++ b/kernel/linux/DETAILS
@@ -1,5 +1,5 @@
           MODULE=linux
-         VERSION=4.17.10
+         VERSION=4.18.5
             BASE=$(echo $VERSION | cut -d. -f1,2)
           SOURCE=$MODULE-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -9,22 +9,22 @@ fi
    SOURCE_URL[1]=http://www.kernel.org/pub/linux/kernel/v4.x
   SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v4.x
   SOURCE2_URL[1]=http://www.kernel.org/pub/linux/kernel/v4.x
-      SOURCE_VFY=sha256:9faa1dd896eaea961dc6e886697c0b3301277102e5bc976b2758f9a62d3ccd13
-     SOURCE2_VFY=sha256:41ad005296c7a1b5245a87881f666b3f4d7aa05a6b9409454b2e473d473c4cee
+      SOURCE_VFY=sha256:19d8bcf49ef530cd4e364a45b4a22fa70714b70349c8100e7308488e26f1eaf1
+     SOURCE2_VFY=sha256:c88a4e56ab8a37e38c76dbb12be53a2a3379e920ce4b86003ccfff8a4a9d1f69
          WEB_SITE=http://www.kernel.org/
          ENTERED=20111121
-         UPDATED=20180725
+         UPDATED=20180827
            SHORT="The core of a Linux GNU Operating System"
      KEEP_SOURCE=on
            TMPFS=off
 
 cat << EOF
-This is the latest stable version the Linux kernel for Lunar Linux distro.
-Linux is a clone of the Unix kernel, written from scratch by Linus Torvalds
-with assistance from a loosely-knit team of hackers across the Net. It aims
-towards POSIX and Single UNIX Specification compliance.
-It has all the features you would expect in a modern fully-fledged Unix kernel,
-including true multitasking, virtual memory, shared libraries, demand loading,
-shared copy-on-write executables, proper memory management, and TCP/IP
-networking.
+This is the latest stable version the Linux kernel for Lunar Linux
+distro.  Linux is a clone of the Unix kernel, written from scratch by
+Linus Torvalds with assistance from a loosely-knit team of hackers
+across the Net. It aims towards POSIX and Single UNIX Specification
+compliance.  It has all the features you would expect in a modern
+fully-fledged Unix kernel, including true multitasking, virtual memory,
+shared libraries, demand loading, shared copy-on-write executables,
+proper memory management, and TCP/IP networking.
 EOF


### PR DESCRIPTION
The 4.17 series kernels are EOL'ed, so may as well switch to the current
stable.