### PR TITLE
findutils: Patch the gnulib files that fail to build with glibc 2.28

### DIFF
--- a/utils/findutils/DETAILS
+++ b/utils/findutils/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d
         WEB_SITE=http://www.gnu.org/software/$MODULE
          ENTERED=20010922
-         UPDATED=20151229
+         UPDATED=20180905
            SHORT="Utilities for locating files"
 
 cat << EOF

--- a/utils/findutils/patch.d/glibc-2.28.patch
+++ b/utils/findutils/patch.d/glibc-2.28.patch
@@ -1,0 +1,606 @@
+diff -C 3 -r findutils-4.6.0.orig/gl/lib/freadahead.c findutils-4.6.0/gl/lib/freadahead.c
+*** findutils-4.6.0.orig/gl/lib/freadahead.c	2015-12-25 01:41:42.000000000 +0900
+--- findutils-4.6.0/gl/lib/freadahead.c	2018-09-05 10:09:35.314546778 +0900
+***************
+*** 1,5 ****
+  /* Retrieve information about a FILE stream.
+!    Copyright (C) 2007-2015 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+--- 1,5 ----
+  /* Retrieve information about a FILE stream.
+!    Copyright (C) 2007-2018 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+***************
+*** 12,18 ****
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+--- 12,18 ----
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+***************
+*** 22,38 ****
+  #include <stdlib.h>
+  #include "stdio-impl.h"
+  
+  size_t
+  freadahead (FILE *fp)
+  {
+! #if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+    if (fp->_IO_write_ptr > fp->_IO_write_base)
+      return 0;
+    return (fp->_IO_read_end - fp->_IO_read_ptr)
+           + (fp->_flags & _IO_IN_BACKUP ? fp->_IO_save_end - fp->_IO_save_base :
+              0);
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+    if ((fp_->_flags & __SWR) != 0 || fp_->_r < 0)
+      return 0;
+  # if defined __DragonFly__
+--- 22,47 ----
+  #include <stdlib.h>
+  #include "stdio-impl.h"
+  
++ #if defined __DragonFly__
++ /* Defined in libc, but not declared in <stdio.h>.  */
++ extern size_t __sreadahead (FILE *);
++ #endif
++ 
++ /* This file is not used on systems that have the __freadahead function,
++    namely musl libc.  */
++ 
+  size_t
+  freadahead (FILE *fp)
+  {
+! #if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
+!   /* GNU libc, BeOS, Haiku, Linux libc5 */
+    if (fp->_IO_write_ptr > fp->_IO_write_base)
+      return 0;
+    return (fp->_IO_read_end - fp->_IO_read_ptr)
+           + (fp->_flags & _IO_IN_BACKUP ? fp->_IO_save_end - fp->_IO_save_base :
+              0);
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+    if ((fp_->_flags & __SWR) != 0 || fp_->_r < 0)
+      return 0;
+  # if defined __DragonFly__
+***************
+*** 53,59 ****
+    if ((fp_->_flags & _IOWRITING) != 0)
+      return 0;
+    return fp_->_count;
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, NonStop Kernel */
+    if ((fp_->_flag & _IOWRT) != 0)
+      return 0;
+    return fp_->_cnt;
+--- 62,68 ----
+    if ((fp_->_flags & _IOWRITING) != 0)
+      return 0;
+    return fp_->_count;
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+    if ((fp_->_flag & _IOWRT) != 0)
+      return 0;
+    return fp_->_cnt;
+diff -C 3 -r findutils-4.6.0.orig/gl/lib/fseeko.c findutils-4.6.0/gl/lib/fseeko.c
+*** findutils-4.6.0.orig/gl/lib/fseeko.c	2015-12-25 01:41:42.000000000 +0900
+--- findutils-4.6.0/gl/lib/fseeko.c	2018-09-05 10:10:26.037937970 +0900
+***************
+*** 1,9 ****
+  /* An fseeko() function that, together with fflush(), is POSIX compliant.
+!    Copyright (C) 2007-2015 Free Software Foundation, Inc.
+  
+     This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation; either version 3, or (at your option)
+     any later version.
+  
+     This program is distributed in the hope that it will be useful,
+--- 1,9 ----
+  /* An fseeko() function that, together with fflush(), is POSIX compliant.
+!    Copyright (C) 2007-2018 Free Software Foundation, Inc.
+  
+     This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+!    the Free Software Foundation; either version 2, or (at your option)
+     any later version.
+  
+     This program is distributed in the hope that it will be useful,
+***************
+*** 12,18 ****
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License along
+!    with this program; if not, see <http://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+--- 12,18 ----
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License along
+!    with this program; if not, see <https://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+***************
+*** 33,41 ****
+  #endif
+  #if _GL_WINDOWS_64_BIT_OFF_T
+  # undef fseeko
+! # if HAVE__FSEEKI64 /* msvc, mingw64 */
+  #  define fseeko _fseeki64
+! # else /* mingw */
+  #  define fseeko fseeko64
+  # endif
+  #endif
+--- 33,41 ----
+  #endif
+  #if _GL_WINDOWS_64_BIT_OFF_T
+  # undef fseeko
+! # if HAVE__FSEEKI64 && HAVE_DECL__FSEEKI64 /* msvc, mingw since msvcrt8.0, mingw64 */
+  #  define fseeko _fseeki64
+! # else /* mingw before msvcrt8.0 */
+  #  define fseeko fseeko64
+  # endif
+  #endif
+***************
+*** 47,58 ****
+  #endif
+  
+    /* These tests are based on fpurge.c.  */
+! #if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+    if (fp->_IO_read_end == fp->_IO_read_ptr
+        && fp->_IO_write_ptr == fp->_IO_write_base
+        && fp->_IO_save_base == NULL)
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+  # if defined __SL64 && defined __SCLE /* Cygwin */
+    if ((fp->_flags & __SL64) == 0)
+      {
+--- 47,59 ----
+  #endif
+  
+    /* These tests are based on fpurge.c.  */
+! #if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
+!   /* GNU libc, BeOS, Haiku, Linux libc5 */
+    if (fp->_IO_read_end == fp->_IO_read_ptr
+        && fp->_IO_write_ptr == fp->_IO_write_base
+        && fp->_IO_save_base == NULL)
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+  # if defined __SL64 && defined __SCLE /* Cygwin */
+    if ((fp->_flags & __SL64) == 0)
+      {
+***************
+*** 80,86 ****
+  #elif defined __minix               /* Minix */
+    if (fp_->_ptr == fp_->_buf
+        && (fp_->_ptr == NULL || fp_->_count == 0))
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, NonStop Kernel */
+    if (fp_->_ptr == fp_->_base
+        && (fp_->_ptr == NULL || fp_->_cnt == 0))
+  #elif defined __UCLIBC__            /* uClibc */
+--- 81,87 ----
+  #elif defined __minix               /* Minix */
+    if (fp_->_ptr == fp_->_buf
+        && (fp_->_ptr == NULL || fp_->_count == 0))
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+    if (fp_->_ptr == fp_->_base
+        && (fp_->_ptr == NULL || fp_->_cnt == 0))
+  #elif defined __UCLIBC__            /* uClibc */
+***************
+*** 117,134 ****
+        if (pos == -1)
+          {
+  #if defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!           /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+            fp_->_flags &= ~__SOFF;
+  #endif
+            return -1;
+          }
+  
+! #if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+        fp->_flags &= ~_IO_EOF_SEEN;
+        fp->_offset = pos;
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!       /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+! # if defined __CYGWIN__ || (defined __NetBSD__ && __NetBSD_Version__ >= 600000000)
+        /* fp_->_offset is typed as an integer.  */
+        fp_->_offset = pos;
+  # else
+--- 118,136 ----
+        if (pos == -1)
+          {
+  #if defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!           /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+            fp_->_flags &= ~__SOFF;
+  #endif
+            return -1;
+          }
+  
+! #if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
+!       /* GNU libc, BeOS, Haiku, Linux libc5 */
+        fp->_flags &= ~_IO_EOF_SEEN;
+        fp->_offset = pos;
+  #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!       /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+! # if defined __CYGWIN__ || (defined __NetBSD__ && __NetBSD_Version__ >= 600000000) || defined __minix
+        /* fp_->_offset is typed as an integer.  */
+        fp_->_offset = pos;
+  # else
+***************
+*** 150,157 ****
+        fp_->_flags &= ~__SEOF;
+  #elif defined __EMX__               /* emx+gcc */
+        fp->_flags &= ~_IOEOF;
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, NonStop Kernel */
+!       fp->_flag &= ~_IOEOF;
+  #elif defined __MINT__              /* Atari FreeMiNT */
+        fp->__offset = pos;
+        fp->__eof = 0;
+--- 152,159 ----
+        fp_->_flags &= ~__SEOF;
+  #elif defined __EMX__               /* emx+gcc */
+        fp->_flags &= ~_IOEOF;
+! #elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+!       fp_->_flag &= ~_IOEOF;
+  #elif defined __MINT__              /* Atari FreeMiNT */
+        fp->__offset = pos;
+        fp->__eof = 0;
+diff -C 3 -r findutils-4.6.0.orig/gl/lib/mountlist.c findutils-4.6.0/gl/lib/mountlist.c
+*** findutils-4.6.0.orig/gl/lib/mountlist.c	2015-12-25 01:41:44.000000000 +0900
+--- findutils-4.6.0/gl/lib/mountlist.c	2018-09-05 10:12:22.118068414 +0900
+***************
+*** 1,6 ****
+  /* mountlist.c -- return a list of mounted file systems
+  
+!    Copyright (C) 1991-1992, 1997-2015 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+--- 1,6 ----
+  /* mountlist.c -- return a list of mounted file systems
+  
+!    Copyright (C) 1991-1992, 1997-2018 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+***************
+*** 13,19 ****
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+--- 13,19 ----
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+  
+  #include <config.h>
+  
+***************
+*** 37,42 ****
+--- 37,48 ----
+  # include <sys/param.h>
+  #endif
+  
++ #if MAJOR_IN_MKDEV
++ # include <sys/mkdev.h>
++ #elif MAJOR_IN_SYSMACROS
++ # include <sys/sysmacros.h>
++ #endif
++ 
+  #if defined MOUNTED_GETFSSTAT   /* OSF_1 and Darwin1.3.x */
+  # if HAVE_SYS_UCRED_H
+  #  include <grp.h> /* needed on OSF V4.0 for definition of NGROUPS,
+***************
+*** 217,229 ****
+  
+  #ifndef ME_REMOTE
+  /* A file system is "remote" if its Fs_name contains a ':'
+!    or if (it is of type (smbfs or cifs) and its Fs_name starts with '//').  */
+  # define ME_REMOTE(Fs_name, Fs_type)            \
+      (strchr (Fs_name, ':') != NULL              \
+       || ((Fs_name)[0] == '/'                    \
+           && (Fs_name)[1] == '/'                 \
+           && (strcmp (Fs_type, "smbfs") == 0     \
+!              || strcmp (Fs_type, "cifs") == 0)))
+  #endif
+  
+  #if MOUNTED_GETMNTINFO
+--- 223,237 ----
+  
+  #ifndef ME_REMOTE
+  /* A file system is "remote" if its Fs_name contains a ':'
+!    or if (it is of type (smbfs or cifs) and its Fs_name starts with '//')
+!    or Fs_name is equal to "-hosts" (used by autofs to mount remote fs).  */
+  # define ME_REMOTE(Fs_name, Fs_type)            \
+      (strchr (Fs_name, ':') != NULL              \
+       || ((Fs_name)[0] == '/'                    \
+           && (Fs_name)[1] == '/'                 \
+           && (strcmp (Fs_type, "smbfs") == 0     \
+!              || strcmp (Fs_type, "cifs") == 0)) \
+!      || (strcmp("-hosts", Fs_name) == 0))
+  #endif
+  
+  #if MOUNTED_GETMNTINFO
+***************
+*** 1068,1073 ****
+--- 1076,1083 ----
+          struct dirent entry;
+          struct dirent *result;
+  
++         /* FIXME: readdir_r is planned to be withdrawn from POSIX and
++            marked obsolescent in glibc.  Use readdir instead.  */
+          if (readdir_r (dirp, &entry, &result) || result == NULL)
+            break;
+  
+diff -C 3 -r findutils-4.6.0.orig/gl/lib/stdio-impl.h findutils-4.6.0/gl/lib/stdio-impl.h
+*** findutils-4.6.0.orig/gl/lib/stdio-impl.h	2015-12-25 01:41:45.000000000 +0900
+--- findutils-4.6.0/gl/lib/stdio-impl.h	2018-09-05 10:10:07.274583301 +0900
+***************
+*** 1,5 ****
+  /* Implementation details of FILE streams.
+!    Copyright (C) 2007-2008, 2010-2015 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+--- 1,5 ----
+  /* Implementation details of FILE streams.
+!    Copyright (C) 2007-2008, 2010-2018 Free Software Foundation, Inc.
+  
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+***************
+*** 12,23 ****
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+  
+  /* Many stdio implementations have the same logic and therefore can share
+     the same implementation of stdio extension API, except that some fields
+     have different naming conventions, or their access requires some casts.  */
+  
+  
+  /* BSD stdio derived implementations.  */
+  
+--- 12,29 ----
+     GNU General Public License for more details.
+  
+     You should have received a copy of the GNU General Public License
+!    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+  
+  /* Many stdio implementations have the same logic and therefore can share
+     the same implementation of stdio extension API, except that some fields
+     have different naming conventions, or their access requires some casts.  */
+  
++ /* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++    problem by defining it ourselves.  FIXME: Do not rely on glibc
++    internals.  */
++ #if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++ # define _IO_IN_BACKUP 0x100
++ #endif
+  
+  /* BSD stdio derived implementations.  */
+  
+***************
+*** 29,38 ****
+  #include <errno.h>                             /* For detecting Plan9.  */
+  
+  #if defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+  
+  # if defined __DragonFly__          /* DragonFly */
+!   /* See <http://www.dragonflybsd.org/cvsweb/src/lib/libc/stdio/priv_stdio.h?rev=HEAD&content-type=text/x-cvsweb-markup>.  */
+  #  define fp_ ((struct { struct __FILE_public pub; \
+                           struct { unsigned char *_base; int _size; } _bf; \
+                           void *cookie; \
+--- 35,44 ----
+  #include <errno.h>                             /* For detecting Plan9.  */
+  
+  #if defined __sferror || defined __DragonFly__ || defined __ANDROID__
+!   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+  
+  # if defined __DragonFly__          /* DragonFly */
+!   /* See <https://gitweb.dragonflybsd.org/dragonfly.git/blob_plain/HEAD:/lib/libc/stdio/priv_stdio.h>.  */
+  #  define fp_ ((struct { struct __FILE_public pub; \
+                           struct { unsigned char *_base; int _size; } _bf; \
+                           void *cookie; \
+***************
+*** 49,78 ****
+                           fpos_t _offset; \
+                           /* More fields, not relevant here.  */ \
+                         } *) fp)
+!   /* See <http://www.dragonflybsd.org/cvsweb/src/include/stdio.h?rev=HEAD&content-type=text/x-cvsweb-markup>.  */
+  #  define _p pub._p
+  #  define _flags pub._flags
+  #  define _r pub._r
+  #  define _w pub._w
+  # else
+  #  define fp_ fp
+  # endif
+  
+! # if (defined __NetBSD__ && __NetBSD_Version__ >= 105270000) || defined __OpenBSD__ || defined __ANDROID__ /* NetBSD >= 1.5ZA, OpenBSD, Android */
+    /* See <http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/stdio/fileext.h?rev=HEAD&content-type=text/x-cvsweb-markup>
+!      and <http://www.openbsd.org/cgi-bin/cvsweb/src/lib/libc/stdio/fileext.h?rev=HEAD&content-type=text/x-cvsweb-markup> */
+    struct __sfileext
+      {
+        struct  __sbuf _ub; /* ungetc buffer */
+        /* More fields, not relevant here.  */
+      };
+  #  define fp_ub ((struct __sfileext *) fp->_ext._base)->_ub
+! # else                                         /* FreeBSD, NetBSD <= 1.5Z, DragonFly, Mac OS X, Cygwin, Android */
+  #  define fp_ub fp_->_ub
+  # endif
+  
+  # define HASUB(fp) (fp_ub._base != NULL)
+  
+  #endif
+  
+  
+--- 55,138 ----
+                           fpos_t _offset; \
+                           /* More fields, not relevant here.  */ \
+                         } *) fp)
+!   /* See <https://gitweb.dragonflybsd.org/dragonfly.git/blob_plain/HEAD:/include/stdio.h>.  */
+  #  define _p pub._p
+  #  define _flags pub._flags
+  #  define _r pub._r
+  #  define _w pub._w
++ # elif defined __ANDROID__ /* Android */
++   /* Up to this commit from 2015-10-12
++      <https://android.googlesource.com/platform/bionic.git/+/f0141dfab10a4b332769d52fa76631a64741297a>
++      the innards of FILE were public, and fp_ub could be defined like for OpenBSD,
++      see <https://android.googlesource.com/platform/bionic.git/+/e78392637d5086384a5631ddfdfa8d7ec8326ee3/libc/stdio/fileext.h>
++      and <https://android.googlesource.com/platform/bionic.git/+/e78392637d5086384a5631ddfdfa8d7ec8326ee3/libc/stdio/local.h>.
++      After this commit, the innards of FILE are hidden.  */
++ #  define fp_ ((struct { unsigned char *_p; \
++                          int _r; \
++                          int _w; \
++                          int _flags; \
++                          int _file; \
++                          struct { unsigned char *_base; size_t _size; } _bf; \
++                          int _lbfsize; \
++                          void *_cookie; \
++                          void *_close; \
++                          void *_read; \
++                          void *_seek; \
++                          void *_write; \
++                          struct { unsigned char *_base; size_t _size; } _ext; \
++                          unsigned char *_up; \
++                          int _ur; \
++                          unsigned char _ubuf[3]; \
++                          unsigned char _nbuf[1]; \
++                          struct { unsigned char *_base; size_t _size; } _lb; \
++                          int _blksize; \
++                          fpos_t _offset; \
++                          /* More fields, not relevant here.  */ \
++                        } *) fp)
+  # else
+  #  define fp_ fp
+  # endif
+  
+! # if (defined __NetBSD__ && __NetBSD_Version__ >= 105270000) || defined __OpenBSD__ || defined __minix /* NetBSD >= 1.5ZA, OpenBSD, Minix 3 */
+    /* See <http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/stdio/fileext.h?rev=HEAD&content-type=text/x-cvsweb-markup>
+!      and <https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/stdio/fileext.h?rev=HEAD&content-type=text/x-cvsweb-markup>
+!      and <https://github.com/Stichting-MINIX-Research-Foundation/minix/blob/master/lib/libc/stdio/fileext.h> */
+    struct __sfileext
+      {
+        struct  __sbuf _ub; /* ungetc buffer */
+        /* More fields, not relevant here.  */
+      };
+  #  define fp_ub ((struct __sfileext *) fp->_ext._base)->_ub
+! # elif defined __ANDROID__                     /* Android */
+!   struct __sfileext
+!     {
+!       struct { unsigned char *_base; size_t _size; } _ub; /* ungetc buffer */
+!       /* More fields, not relevant here.  */
+!     };
+! #  define fp_ub ((struct __sfileext *) fp_->_ext._base)->_ub
+! # else                                         /* FreeBSD, NetBSD <= 1.5Z, DragonFly, Mac OS X, Cygwin */
+  #  define fp_ub fp_->_ub
+  # endif
+  
+  # define HASUB(fp) (fp_ub._base != NULL)
+  
++ # if defined __ANDROID__ /* Android */
++   /* Needed after this commit from 2016-01-25
++      <https://android.googlesource.com/platform/bionic.git/+/e70e0e9267d069bf56a5078c99307e08a7280de7> */
++ #  ifndef __SEOF
++ #   define __SLBF 1
++ #   define __SNBF 2
++ #   define __SRD 4
++ #   define __SWR 8
++ #   define __SRW 0x10
++ #   define __SEOF 0x20
++ #   define __SERR 0x40
++ #  endif
++ #  ifndef __SOFF
++ #   define __SOFF 0x1000
++ #  endif
++ # endif
++ 
+  #endif
+  
+  
+***************
+*** 81,87 ****
+  #ifdef __TANDEM                     /* NonStop Kernel */
+  # ifndef _IOERR
+  /* These values were determined by the program 'stdioext-flags' at
+!    <http://lists.gnu.org/archive/html/bug-gnulib/2010-12/msg00165.html>.  */
+  #  define _IOERR   0x40
+  #  define _IOREAD  0x80
+  #  define _IOWRT    0x4
+--- 141,147 ----
+  #ifdef __TANDEM                     /* NonStop Kernel */
+  # ifndef _IOERR
+  /* These values were determined by the program 'stdioext-flags' at
+!    <https://lists.gnu.org/r/bug-gnulib/2010-12/msg00165.html>.  */
+  #  define _IOERR   0x40
+  #  define _IOREAD  0x80
+  #  define _IOWRT    0x4
+***************
+*** 99,104 ****
+--- 159,166 ----
+                           int _file; \
+                           unsigned int _flag; \
+                         } *) fp)
++ # elif defined __VMS                /* OpenVMS */
++ #  define fp_ ((struct _iobuf *) fp)
+  # else
+  #  define fp_ fp
+  # endif
+***************
+*** 110,113 ****
+--- 172,202 ----
+  #  define _flag __flag
+  # endif
+  
++ #elif defined _WIN32 && ! defined __CYGWIN__  /* newer Windows with MSVC */
++ 
++ /* <stdio.h> does not define the innards of FILE any more.  */
++ # define WINDOWS_OPAQUE_FILE
++ 
++ struct _gl_real_FILE
++ {
++   /* Note: Compared to older Windows and to mingw, it has the fields
++      _base and _cnt swapped. */
++   unsigned char *_ptr;
++   unsigned char *_base;
++   int _cnt;
++   int _flag;
++   int _file;
++   int _charbuf;
++   int _bufsiz;
++ };
++ # define fp_ ((struct _gl_real_FILE *) fp)
++ 
++ /* These values were determined by a program similar to the one at
++    <https://lists.gnu.org/r/bug-gnulib/2010-12/msg00165.html>.  */
++ # define _IOREAD   0x1
++ # define _IOWRT    0x2
++ # define _IORW     0x4
++ # define _IOEOF    0x8
++ # define _IOERR   0x10
++ 
+  #endif
+Only in findutils-4.6.0.orig: tool-versions.txt


### PR DESCRIPTION
I just took the code directly from the gnulib project, unchanged, so
this patch appears to have unrelated things in it.