### PR TITLE
systemd: backport fix for resolvconf

### DIFF
--- a/system/systemd/DETAILS
+++ b/system/systemd/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:8a11b1b07d620f4c06a16e95bba4dd2a97e90efdf2a5ba47ed0a935085787a14
         WEB_SITE=http://www.freedesktop.org/wiki/Software/systemd
          ENTERED=20100919
-         UPDATED=20180809
+         UPDATED=20180917
            SHORT="A system and program management daemon"
 
 cat << EOF

--- a/system/systemd/patch.d/systemd-resolvconf-fix.patch
+++ b/system/systemd/patch.d/systemd-resolvconf-fix.patch
@@ -1,0 +1,57 @@
+commit 5a01b3f35d7b6182c78b6973db8d99bdabd4f9c3
+Author:     Filipe Brandenburger <filbranden@google.com>
+AuthorDate: Mon Jun 25 18:07:48 2018 -0700
+Commit:     Filipe Brandenburger <filbranden@google.com>
+CommitDate: Tue Jun 26 23:09:36 2018 -0700
+
+    resolvconf: fixes for the compatibility interface
+    
+    Also use compat_main() when called as `resolvconf`, since the interface
+    is closer to that of `systemd-resolve`.
+    
+    Use a heap allocated string to set arg_ifname, since a stack allocated
+    one would be lost after the function returns. (This last one broke the
+    case where an interface name was suffixed with a dot, such as in
+    `resolvconf -a tap0.dhcp`.)
+    
+    Tested:
+      $ build/resolvconf -a nonexistent.abc </etc/resolv.conf
+      Unknown interface 'nonexistent': No such device
+    
+    Fixes #9423.
+
+diff --git a/src/resolve/resolvconf-compat.c b/src/resolve/resolvconf-compat.c
+index d7e68003e..072345894 100644
+--- a/src/resolve/resolvconf-compat.c
++++ b/src/resolve/resolvconf-compat.c
+@@ -53,6 +53,8 @@ static int parse_nameserver(const char *string) {
+ 
+                 if (strv_push(&arg_set_dns, word) < 0)
+                         return log_oom();
++
++                word = NULL;
+         }
+ 
+         return 0;
+@@ -202,7 +204,7 @@ int resolvconf_parse_argv(int argc, char *argv[]) {
+ 
+         dot = strchr(argv[optind], '.');
+         if (dot) {
+-                iface = strndupa(argv[optind], dot - argv[optind]);
++                iface = strndup(argv[optind], dot - argv[optind]);
+                 log_debug("Ignoring protocol specifier '%s'.", dot + 1);
+         } else
+                 iface = argv[optind];
+diff --git a/src/resolve/resolvectl.c b/src/resolve/resolvectl.c
+index e96c13fea..e9e395e3e 100644
+--- a/src/resolve/resolvectl.c
++++ b/src/resolve/resolvectl.c
+@@ -3092,7 +3092,7 @@ int main(int argc, char **argv) {
+                 goto finish;
+         }
+ 
+-        if (streq(program_invocation_short_name, "systemd-resolve"))
++        if (STR_IN_SET(program_invocation_short_name, "systemd-resolve", "resolvconf"))
+                 r = compat_main(argc, argv, bus);
+         else
+                 r = native_main(argc, argv, bus);


### PR DESCRIPTION
Without the patch the resolvconf entries are dropped silently.

Required to have dhcpcd working with systemd-resolved