### PR TITLE
openssl: I think maybe I was a bit overenthusiastic in my assumptions.

### DIFF
--- a/crypto/openssl/BUILD
+++ b/crypto/openssl/BUILD
@@ -17,7 +17,10 @@ sedit "s/^CFLAG=/CFLAG=$CFLAGS /g" Makefile &&
 make &&
 mkdir _dest &&
 make MANDIR=/usr/share/man INSTALL_PREFIX=$(pwd)/_dest install &&
-mv _dest/usr/lib64 _dest/usr/lib &&
+if [ -d _dest/usr/lib64 ]
+then
+    mv _dest/usr/lib64 _dest/usr/lib
+fi &&
 prepare_install &&
 ( cd _dest && cp -r * /) &&
 cp $SOURCE_CACHE/$SOURCE2 /etc/ssl/certs/Makefile


### PR DESCRIPTION
Check for the actual existence of /usr/lib64 before arbitrarily renaming
it /usr/lib first.