### PR TITLE
systemd: meson doesn't like the option "debug" any more.

### DIFF
--- a/system/systemd/DETAILS
+++ b/system/systemd/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:8a11b1b07d620f4c06a16e95bba4dd2a97e90efdf2a5ba47ed0a935085787a14
         WEB_SITE=http://www.freedesktop.org/wiki/Software/systemd
          ENTERED=20100919
-         UPDATED=20180917
+         UPDATED=20181011
            SHORT="A system and program management daemon"
 
 cat << EOF

--- a/system/systemd/patch.d/meson-build.patch
+++ b/system/systemd/patch.d/meson-build.patch
@@ -1,0 +1,19 @@
+*** systemd-239/meson.build.orig        2018-10-11 14:50:47.269516356 +0900
+--- systemd-239/meson.build     2018-10-11 14:50:52.382852318 +0900
+***************
+*** 764,770 ****
+
+  enable_debug_hashmap = false
+  enable_debug_mmap_cache = false
+! foreach name : get_option('debug')
+          if name == 'hashmap'
+                  enable_debug_hashmap = true
+          elif name == 'mmap-cache'
+--- 764,770 ----
+
+  enable_debug_hashmap = false
+  enable_debug_mmap_cache = false
+! foreach name : get_option('debug-extra')
+          if name == 'hashmap'
+                  enable_debug_hashmap = true
+          elif name == 'mmap-cache'

--- a/system/systemd/patch.d/meson-options.patch
+++ b/system/systemd/patch.d/meson-options.patch
@@ -1,0 +1,19 @@
+*** systemd-239/meson_options.txt.orig  2018-10-11 11:09:29.394008442 +0900
+--- systemd-239/meson_options.txt       2018-10-11 14:50:07.266162388 +0900
+***************
+*** 46,52 ****
+         description : 'path to debug shell binary')
+  option('debug-tty', type : 'string', value : '/dev/tty9',
+         description : 'specify the tty device for debug shell')
+! option('debug', type : 'array', choices : ['hashmap', 'mmap-cache'], value : [],
+         description : 'enable extra debugging')
+  option('memory-accounting-default', type : 'boolean',
+         description : 'enable MemoryAccounting= by default')
+--- 46,52 ----
+         description : 'path to debug shell binary')
+  option('debug-tty', type : 'string', value : '/dev/tty9',
+         description : 'specify the tty device for debug shell')
+! option('debug-extra', type : 'array', choices : ['hashmap', 'mmap-cache'], value : [],
+         description : 'enable extra debugging')
+  option('memory-accounting-default', type : 'boolean',
+         description : 'enable MemoryAccounting= by default')


### PR DESCRIPTION
Apparently it's used for its own internal things.  So let's call this
"debug-extra" and see if that works.