### PR TITLE
glibc: Change BUILD so that installwatch sees everything.

### DIFF
--- a/libs/glibc/BUILD
+++ b/libs/glibc/BUILD
@@ -23,9 +23,9 @@
   fi  &&
   unset LDFLAGS  &&
 
-  INSTALL_ROOT=$SOURCE_DIRECTORY/glibcroot  &&
-  mkdir -p $INSTALL_ROOT  &&
-  cd $INSTALL_ROOT  &&
+  BUILD_ROOT=$SOURCE_DIRECTORY/glibcbuild  &&
+  mkdir -p $BUILD_ROOT  &&
+  cd $BUILD_ROOT  &&
 
   ../configure --prefix=/usr              \
                --infodir=/usr/share/info  \
@@ -106,14 +106,20 @@
     sln /lib/libmvec-lunar.so $MVEC
   fi &&
 
-  # clean hack to make sure gnu/stubs.h gets refreshed
-  rm -f /usr/include/gnu/stubs.h  &&
-
-  # This removes the old glibc
-  prepare_install  &&
+  INSTALL_ROOT=$SOURCE_DIRECTORY/glibcroot &&
+  mkdir -p $INSTALL_ROOT &&
 
   # And now we install the new
-  make install  &&
+  make install DESTDIR=$INSTALL_ROOT &&
+
+  export LD_LIBRARY_PATH=$INSTALL_ROOT/lib:$INSTALL_ROOT/usr/lib &&
+
+  # This removes the old glibc
+  prepare_install &&
+
+  ( cd $INSTALL_ROOT &&
+
+    lib/ld-linux.so /usr/bin/cp -a -r --remove-destination * / ) &&
 
   # Now optionally perform debug symbol stripping only
   if [ "$STRIP" == "y" ] ; then

--- a/libs/glibc/BUILD.x86_64
+++ b/libs/glibc/BUILD.x86_64
@@ -20,7 +20,7 @@ if [[ "$LDFLAGS" == *-s* ]]; then
 fi &&
 unset LDFLAGS &&
 
-INSTALL_ROOT=$SOURCE_DIRECTORY/glibcroot &&
+INSTALL_ROOT=$SOURCE_DIRECTORY/glibcbuild &&
 mkdir -p $INSTALL_ROOT &&
 cd $INSTALL_ROOT &&
 
@@ -103,14 +103,23 @@ if [ -f "$MVEC" ]; then
   sln /lib/libmvec-lunar.so $MVEC
 fi &&
 
-# clean hack to make sure gnu/stubs.h gets refreshed
-rm -f /usr/include/gnu/stubs.h &&
+INSTALL_ROOT=$SOURCE_DIRECTORY/glibcroot &&
+mkdir -p $INSTALL_ROOT &&
+
+# And now we install the new
+make install DESTDIR=$INSTALL_ROOT &&
+
+[ -d $INSTALL_ROOT/lib64 ] && mv $INSTALL_ROOT/lib64 $INSTALL_ROOT/lib &&
+[ -d $INSTALL_ROOT/usr/lib64 ] && mv $INSTALL_ROOT/usr/lib64 $INSTALL_ROOT/usr/lib &&
+
+export LD_LIBRARY_PATH=$INSTALL_ROOT/lib:$INSTALL_ROOT/usr/lib &&
 
 # This removes the old glibc
 prepare_install &&
 
-# And now we install the new
-make install &&
+( cd $INSTALL_ROOT &&
+
+  cp -a -r --remove-destination * / ) &&
 
 # Now optionally perform debug symbol stripping only
 if [ "$STRIP" == "y" ] ; then


### PR DESCRIPTION
Parts of the normal `make install` of glibc install things using a
system call that installwatch doesn't know about.  So until installwatch
is fixed, we're generating faulty ISOs with files missing.

This is a workaround for that.