### PR TITLE
bzip2: Fix URL.

### DIFF
--- a/archive/bzip2/DETAILS
+++ b/archive/bzip2/DETAILS
@@ -2,13 +2,13 @@
          VERSION=1.0.6
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=$MODULE-$VERSION-CVE-2016-3189.patch
-       SOURCE_URL=$SFORGE_URL
+       SOURCE_URL=https://fossies.org/linux/misc/
       SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha256:a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
      SOURCE2_VFY=sha256:b11f836f4abcc746ab76109728b1fb3e131a1fe0d3c2adfa640d99b02ff8a5a4
         WEB_SITE=http://www.bzip.org
          ENTERED=20020218
-         UPDATED=20181127
+         UPDATED=20190225
            SHORT="High-quality data compressor"
 
 cat << EOF


### PR DESCRIPTION
SourceForge has decided that their URLs are now going to be INCREDIBLY
STUPID, appending "/download" after the actual filename of what you want
to download.

Until we figure out how to get around this, use alternative mirrors I
guess.