### PR TITLE
efibootmgr: Add patch because an earlier hack broke the build

### DIFF
--- a/system/efibootmgr/DETAILS
+++ b/system/efibootmgr/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:22a95ebe0d5c9fb2915b3a100450f8f37484d1dbb8b296f55b343cc84f10397d
         WEB_SITE=http://github.com/rhinstaller/efibootmgr/
          ENTERED=20160723
-         UPDATED=20181221
+         UPDATED=20190402
            SHORT="Tool to modify UEFI Firmware Boot Manager Variables"
 
 cat << EOF

--- a/system/efibootmgr/patch.d/fix-conflicting-declaration.patch
+++ b/system/efibootmgr/patch.d/fix-conflicting-declaration.patch
@@ -1,0 +1,17 @@
+diff -C 4 -r efibootmgr-17/src/efibootmgr.c efibootmgr-17/src/efibootmgr.c
+*** efibootmgr-17/src/efibootmgr.c	2018-06-11 05:12:10.000000000 +0900
+--- efibootmgr-17/src/efibootmgr.c	2019-04-02 14:49:40.229838753 +0900
+***************
+*** 1535,1545 ****
+  					errorx(39,
+  					       "invalid numeric value %s\n",
+  					       optarg);
+  			}
+-                         /* XXX efivar-36 accidentally doesn't have a public
+-                          * header for this */
+- 			extern int efi_set_verbose(int verbosity, FILE *errlog);
+  			efi_set_verbose(opts.verbose - 2, stderr);
+  			break;
+  		case 'V':
+  			opts.showversion = 1;
+--- 1535,1542 ----


### PR DESCRIPTION
Specifically, the earlier hack was putting in a declaration for
efi_set_verbose, which turned out to be incorrect.

Whoopsie!

This fix is actually in the efibootmgr code that's on github, but there
hasn't been a release in a long time.