### PR TITLE
glibc: Now has a hard dependency on python.

### DIFF
--- a/libs/glibc/DEPENDS
+++ b/libs/glibc/DEPENDS
@@ -1,6 +1,7 @@
 depends gawk
 depends sed
 depends texinfo
+depends python
 depends %KERNEL_HEADERS
 
 optional_depends perl "" "" "for testing the installation"


### PR DESCRIPTION
This kind of needs to be made explicit when bootstrapping (like when
building an ISO).