### PR TITLE
gcc: Make the package archive a lot smaller

### DIFF
--- a/compilers/gcc/BUILD
+++ b/compilers/gcc/BUILD
@@ -41,6 +41,9 @@ make CFLAGS='-O' LIBCFLAGS='-g -O2' LIBCXXFLAGS='-g -O2 -fno-implicit-templates'
 prepare_install &&
 make install &&
 
+( cd /usr/lib/gcc/`arch`-pc-linux-gnu/$VERSION &&
+  strip cc1 cc1plus lto1 ) &&
+
 install -d /usr/share/gdb/auto-load &&
 mv /usr/lib/libstdc++.so.6.*-gdb.py /usr/share/gdb/auto-load/ &&
 


### PR DESCRIPTION
Stripping these three executables makes the package half a gigabyte
smaller!  That's like more than half the size of the ISO right there.