### PR TITLE
kmod: When built with prefix=/, it puts the pkgconf file in the wrong place.

### DIFF
--- a/kernel/kmod/BUILD
+++ b/kernel/kmod/BUILD
@@ -12,6 +12,10 @@ default_make &&
 
 install -dm755 /{etc,usr/lib}/{depmod,modprobe}.d &&
 
+# Wy do you make me do awful things?
+mv /lib/pkgconfig/libkmod.pc /usr/lib/pkgconfig &&
+rmdir /lib/pkgconfig
+
 # add symlinks to kmod
 ln -sf /bin/kmod "/bin/lsmod"  &&
 for tool in {ins,rm,dep}mod mod{info,probe}; do


### PR DESCRIPTION
So after the build is done, move libkmod.pc to the correct location.

This is probably an evil hack.