### PR TITLE
readline: Version bumped to 8.0.

### DIFF
--- a/libs/readline/DETAILS
+++ b/libs/readline/DETAILS
@@ -1,18 +1,13 @@
           MODULE=readline
-         VERSION=6.2
+         VERSION=8.0
           SOURCE=$MODULE-$VERSION.tar.gz
-         SOURCE2=readline62-001
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.cwru.edu/pub/bash
    SOURCE_URL[2]=ftp://ftp.gnu.org/pub/gnu/$MODULE
-      SOURCE_VFY=sha256:79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381
-  SOURCE2_URL[0]=$GNU_URL/$MODULE/$MODULE-$VERSION-patches
-  SOURCE2_URL[1]=ftp://ftp.cwru.edu/pub/bash/$MODULE-$VERSION-patches
-  SOURCE2_URL[2]=ftp://ftp.gnu.org/pub/gnu/$MODULE/$MODULE-$VERSION-patches
-     SOURCE2_VFY=sha256:38a86c417437692db01069c8ab40a9a8f548e67ad9af0390221b024b1c39b4e3
+      SOURCE_VFY=sha256:e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461
         WEB_SITE=http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html
          ENTERED=20010922
-         UPDATED=20110301
+         UPDATED=20190604
            SHORT="Lets users edit command lines as they are typed in"
 
 cat << EOF

--- a/libs/readline/PRE_BUILD
+++ b/libs/readline/PRE_BUILD
@@ -1,4 +1,0 @@
-default_pre_build &&
-
-patch_it $SOURCE2 0
-


### PR DESCRIPTION
This hasn't been updated in eight years!

Mainly because of all the trouble bumping readline causes on your live system.  It'd be nice for the ISO though.