### PR TITLE
systemd: fix compilation with latest gcc9

### DIFF
--- a/system/systemd/patch.d/0006-networkd-link-compilation-error-fix-b29afb9f.patch
+++ b/system/systemd/patch.d/0006-networkd-link-compilation-error-fix-b29afb9f.patch
@@ -1,0 +1,13 @@
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -321,8 +321,7 @@ static int link_enable_ipv6(Link *link) {
+ 
+         r = sysctl_write_ip_property_boolean(AF_INET6, link->ifname, "disable_ipv6", disabled);
+         if (r < 0)
+-                log_link_warning_errno(link, r, "Cannot %s IPv6 for interface %s: %m",
+-                                       enable_disable(!disabled), link->ifname);
++                log_link_warning_errno(link, r, "Cannot %s IPv6: %m", enable_disable(!disabled));
+         else
+                 log_link_info(link, "IPv6 successfully %sd", enable_disable(!disabled));
+ 
+ 


### PR DESCRIPTION
systemd upstream fix b29afb9f3fe9a1d44accd7a47691bee9391c1db2