### PR TITLE
Timezone data 2019b

### DIFF
--- a/utils/timezone-data/DETAILS
+++ b/utils/timezone-data/DETAILS
@@ -1,20 +1,17 @@
           MODULE=timezone-data
-           TZONE=a
+           TZONE=b
          VERSION=2019$TZONE
           SOURCE=tzdata$VERSION.tar.gz
          SOURCE2=tzcode$VERSION.tar.gz
-         SOURCE3=$MODULE-2018b-makefile.patch
    SOURCE_URL[0]=https://www.iana.org/time-zones/repository/releases
    SOURCE_URL[1]=$MIRROR_URL
   SOURCE2_URL[0]=http://www.iana.org/time-zones/repository/releases
   SOURCE2_URL[1]=$MIRROR_URL
-  SOURCE3_URL[0]=$PATCH_URL
-      SOURCE_VFY=sha256:90366ddf4aa03e37a16cd49255af77f801822310b213f195e2206ead48c59772
-     SOURCE2_VFY=sha256:8739f162bc30cdfb482435697f969253abea49595541a0afd5f443fbae433ff5
-     SOURCE3_VFY=sha256:279d99c676758f918fe061cc64791123a109f85f1ddfdf677593999ae47d8877
+      SOURCE_VFY=sha256:05d9092c90dcf9ec4f3ccfdea80c7dcea5e882b3b105c3422da172aaa9a50c64
+     SOURCE2_VFY=sha256:2e479d409337da41408629ce6c3b4d8410b10ba6d4431d862e22d2b137d7756d
         WEB_SITE=ftp://munnari.oz.au/pub
          ENTERED=20070203
-         UPDATED=20190326
+         UPDATED=20190703
            SHORT="Timezone data and utilities"
 
 cat << EOF

--- a/utils/timezone-data/PRE_BUILD
+++ b/utils/timezone-data/PRE_BUILD
@@ -6,6 +6,4 @@ cp $SOURCE_CACHE/$SOURCE2 $SOURCE_DIRECTORY/ &&
 
 cd $SOURCE_DIRECTORY &&
 unpack $SOURCE  &&
-unpack $SOURCE2 &&
-
-patch_it $SOURCE3 1
+unpack $SOURCE2

--- a/utils/timezone-data/patch.d/makefile.patch
+++ b/utils/timezone-data/patch.d/makefile.patch
@@ -1,0 +1,11 @@
+--- ./Makefile.orig	2018-01-17 11:05:36.000000000 +0200
++++ ./Makefile	2018-01-23 19:53:36.120170825 +0200
+@@ -515,8 +515,6 @@
+ 		cp tzselect '$(DESTDIR)$(BINDIR)/.'
+ 		cp zdump '$(DESTDIR)$(ZDUMPDIR)/.'
+ 		cp zic '$(DESTDIR)$(ZICDIR)/.'
+-		cp libtz.a '$(DESTDIR)$(LIBDIR)/.'
+-		$(RANLIB) '$(DESTDIR)$(LIBDIR)/libtz.a'
+ 		cp -f newctime.3 newtzset.3 '$(DESTDIR)$(MANDIR)/man3/.'
+ 		cp -f tzfile.5 '$(DESTDIR)$(MANDIR)/man5/.'
+ 		cp -f tzselect.8 zdump.8 zic.8 '$(DESTDIR)$(MANDIR)/man8/.'


### PR DESCRIPTION
This bumps the timezone-data version to 2019b, and moves the Makefile patch into the moonbase.