### PR TITLE
Ca-certificates: version bump to 20190110

### DIFF
--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,7 +1,6 @@
           MODULE=ca-certificates
          VERSION=20190110
           SOURCE=${MODULE}_$VERSION.tar.xz
-SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE}
       SOURCE_URL=http://cdn-fastly.deb.debian.org/debian/pool/main/c/$MODULE
       SOURCE_VFY=sha256:ee4bf0f4c6398005f5b5ca4e0b87b82837ac5c3b0280a1cb3a63c47555c3a675
         WEB_SITE=http://packages.qa.debian.org/c/ca-certificates.html

--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,12 +1,12 @@
           MODULE=ca-certificates
-         VERSION=20180409
+         VERSION=20190110
           SOURCE=${MODULE}_$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE}
       SOURCE_URL=http://cdn-fastly.deb.debian.org/debian/pool/main/c/$MODULE
-      SOURCE_VFY=sha256:7af6f5bfc619fd29cbf0258c1d95107c38ce840ad6274e343e1e0d971fc72b51
+      SOURCE_VFY=sha256:ee4bf0f4c6398005f5b5ca4e0b87b82837ac5c3b0280a1cb3a63c47555c3a675
         WEB_SITE=http://packages.qa.debian.org/c/ca-certificates.html
          ENTERED=20100405
-         UPDATED=20180908
+         UPDATED=20190703
            SHORT="Common CA certificates"
 
 cat << EOF

--- a/crypto/ca-certificates/patch.d/ssl_version_compatibility.patch
+++ b/crypto/ca-certificates/patch.d/ssl_version_compatibility.patch
@@ -1,26 +1,40 @@
-diff -Naur ca-certificates.orig/sbin/update-ca-certificates ca-certificates/sbin/update-ca-certificates
---- ca-certificates.orig/sbin/update-ca-certificates	2018-04-10 01:43:49.000000000 +0200
-+++ ca-certificates/sbin/update-ca-certificates	2018-09-08 18:01:03.544853802 +0200
-@@ -171,12 +171,20 @@
- 
- if [ "$ADDED_CNT" -gt 0 ] || [ "$REMOVED_CNT" -gt 0 ]
- then
-+  # Added support to handle older openssl and libressl
-   # only run if set of files has changed
-+  if type c_rehash &> /dev/null; then
-+    SSLCMD="c_rehash"
-+  elif openssl version | grep -q '^OpenSSL'; then
-+    SSLCMD="openssl rehash"
-+  else # Assume libressl
-+    SSLCMD="openssl certhash"
-+  fi
-   if [ "$verbose" = 0 ]
-   then
--    openssl rehash . > /dev/null
-+    $SSLCMD . > /dev/null
-   else
--    openssl rehash .
-+    $SSLCMD .
-   fi
- fi
- 
+diff -C 4 -r ca-certificates-20190110.orig/sbin/update-ca-certificates ca-certificates-20190110/sbin/update-ca-certificates
+*** ca-certificates-20190110.orig/sbin/update-ca-certificates	2019-07-04 13:44:59.913020208 +0900
+--- ca-certificates-20190110/sbin/update-ca-certificates	2019-07-04 13:46:45.009898816 +0900
+***************
+*** 180,192 ****
+      if [ "$verbose" = 1 ]; then
+        echo "Removed orphan symlink $orphan"
+      fi
+    done
+    if [ "$verbose" = 0 ]
+    then
+!     openssl rehash . > /dev/null
+    else
+!     openssl rehash -v .
+    fi
+  fi
+  
+  chmod 0644 "$TEMPBUNDLE"
+--- 180,200 ----
+      if [ "$verbose" = 1 ]; then
+        echo "Removed orphan symlink $orphan"
+      fi
+    done
++   # Added support to handle older openssl and libressl
++   if type c_rehash &> /dev/null; then
++     SSLCMD="c_rehash"
++   elif openssl version | grep -q '^OpenSSL'; then
++     SSLCMD="openssl rehash"
++   else # Assume libressl
++     SSLCMD="openssl certhash"
++   fi
+    if [ "$verbose" = 0 ]
+    then
+!     $SSLCMD . > /dev/null
+    else
+!     $SSLCMD -v .
+    fi
+  fi
+  
+  chmod 0644 "$TEMPBUNDLE"


### PR DESCRIPTION
The current version actually got removed, which means that the normally-good advice to just "lin ca-certificates" whenever curl or wget stop working is now invalid.  Whoops.