### PR TITLE
Linux: Roll back version to 4.9.58 to see if dracut starts working again

### DIFF
--- a/kernel/linux/DETAILS
+++ b/kernel/linux/DETAILS
@@ -1,5 +1,5 @@
           MODULE=linux
-         VERSION=4.9.59
+         VERSION=4.19.59
             BASE=$(echo $VERSION | cut -d. -f1,2)
    MAJOR_RELEASE=${VERSION%%.*}
           SOURCE=$MODULE-$BASE.tar.xz
@@ -11,7 +11,7 @@ fi
   SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v${MAJOR_RELEASE}.x
   SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v${MAJOR_RELEASE}.x
       SOURCE_VFY=sha256:029098dcffab74875e086ae970e3828456838da6e0ba22ce3f64ef764f3d7f1a
-     SOURCE2_VFY=sha256:2490246b965c7df24208e6e3512ff19c69e0603435865fda5152195eab073800
+     SOURCE2_VFY=sha256:6551b81c5b73b230a7889198d6547a9beb4be03715ac0edba948fd7fae76b790
          WEB_SITE=https://www.kernel.org/
          ENTERED=20111121
          UPDATED=20190716

--- a/kernel/linux/DETAILS
+++ b/kernel/linux/DETAILS
@@ -10,7 +10,7 @@ fi
    SOURCE_URL[1]=https://www.kernel.org/pub/linux/kernel/v${MAJOR_RELEASE}.x
   SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v${MAJOR_RELEASE}.x
   SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v${MAJOR_RELEASE}.x
-      SOURCE_VFY=sha256:029098dcffab74875e086ae970e3828456838da6e0ba22ce3f64ef764f3d7f1a
+      SOURCE_VFY=sha256:0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
      SOURCE2_VFY=sha256:6551b81c5b73b230a7889198d6547a9beb4be03715ac0edba948fd7fae76b790
          WEB_SITE=https://www.kernel.org/
          ENTERED=20111121

--- a/kernel/linux/DETAILS
+++ b/kernel/linux/DETAILS
@@ -1,19 +1,20 @@
           MODULE=linux
-         VERSION=5.1.10
+         VERSION=4.9.59
             BASE=$(echo $VERSION | cut -d. -f1,2)
+   MAJOR_RELEASE=${VERSION%%.*}
           SOURCE=$MODULE-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
          SOURCE2=patch-$VERSION.xz
 fi
-   SOURCE_URL[0]=$KERNEL_URL/pub/linux/kernel/v5.x
-   SOURCE_URL[1]=https://www.kernel.org/pub/linux/kernel/v5.x
-  SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v5.x
-  SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v5.x
-      SOURCE_VFY=sha256:d06a7be6e73f97d1350677ad3bae0ce7daecb79c2c2902aaabe806f7fa94f041
-     SOURCE2_VFY=sha256:d50fd9b01c35b161d0e116a0f4950afebc191d231e903f299c55270b491400a1
+   SOURCE_URL[0]=$KERNEL_URL/pub/linux/kernel/v${MAJOR_RELEASE}.x
+   SOURCE_URL[1]=https://www.kernel.org/pub/linux/kernel/v${MAJOR_RELEASE}.x
+  SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v${MAJOR_RELEASE}.x
+  SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v${MAJOR_RELEASE}.x
+      SOURCE_VFY=sha256:029098dcffab74875e086ae970e3828456838da6e0ba22ce3f64ef764f3d7f1a
+     SOURCE2_VFY=sha256:2490246b965c7df24208e6e3512ff19c69e0603435865fda5152195eab073800
          WEB_SITE=https://www.kernel.org/
          ENTERED=20111121
-         UPDATED=20190615
+         UPDATED=20190716
            SHORT="The core of a Linux GNU Operating System"
      KEEP_SOURCE=on
            TMPFS=off


### PR DESCRIPTION
This is for the worst-case scenario: we can't get booting install media at all with 5.x kernels.