### PR TITLE
lvm2: Roll back bump to 2.03.04

### DIFF
--- a/filesys/lvm2/BUILD
+++ b/filesys/lvm2/BUILD
@@ -1,48 +1,24 @@
-cp -a ../LVM2.$VERSION ../LVM2-initramfs &&
-
 if ! [[ $(arch) == x86_64 ]]; then
   CFLAGS+=" -fPIE " &&
   LDFLAGS+=" -pie "
 fi
 
-OPTS+=" --with-udev_prefix=/usr"
 if module_installed systemd; then
-  OPTS+=" --with-systemdsystemunitdir=/usr/lib/systemd/system"
-fi
-
-if module_installed udev || module_installed eudev ; then
-   OPTS+=" --enable-udev_sync \
-           --enable-udev_rules"
+  OPTS+=" --with-udev_prefix=/usr \
+          --with-systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir)"
 else
-  OPTS+=" --enable-udev_sync=no \
-          --enable-udev_rules=no \
-          --enable-udev-rule-exec-detection=no \
-          --enable-udev-systemd-background-jobs=no"
-fi
+  OPTS+=" --with-udev_prefix=/"
+fi &&
 
 OPTS+=" --libdir=/usr/lib  \
-        --enable-fsadm     \
         --enable-cmdlib    \
         --enable-pkgconfig \
-        --enable-dmeventd"
+        --enable-fsadm     \
+        --enable-dmeventd  \
+        --enable-applib    \
+        --enable-udev_sync \
+        --enable-udev_rules"
 
 default_build &&
 
-# extra udev rule for device-mapper in initramfs
-install -D -m644 "${SCRIPT_DIRECTORY}/11-dm-initramfs.rules" /usr/lib/initcpio/udev/ &&
-
-make install_system_dirs &&
-
-cd ../LVM2-initramfs &&
-
-OPTS+=" --enable-udev_sync=no \
-      ¦ --enable-udev_rules=no \
-      ¦ --enable-udev-systemd-background-jobs=no"
-
-./configure $OPTS &&
-cd udev &&
-make 69-dm-lvm-metad.rules &&
-
-# extra udev rule for lvmetad in non-systemd initramfs
-mkdir -p /usr/lib/dracut/modules.d/90lvm &&
-install -D -m644 69-dm-lvm-metad.rules /usr/lib/dracut/modules.d/90lvm/
+make install_system_dirs

--- a/filesys/lvm2/DEPENDS
+++ b/filesys/lvm2/DEPENDS
@@ -1,7 +1,6 @@
 depends readline
 depends pkgconf
 depends libaio
-depends util-linux
 
 # optional circular depend with systemd->cryptsetup
-optional_depends %UDEV "" "" "udev support can only be kept in initramfs"
+depends %UDEV

--- a/filesys/lvm2/DETAILS
+++ b/filesys/lvm2/DETAILS
@@ -1,13 +1,13 @@
           MODULE=lvm2
-         VERSION=2.03.05
+         VERSION=2.03.02
           SOURCE=LVM2.$VERSION.tgz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/LVM2.$VERSION
    SOURCE_URL[0]=https://sourceware.org/pub/lvm2/
    SOURCE_URL[1]=ftp://sources.redhat.com/pub/lvm2/old
-      SOURCE_VFY=sha256:ca52815c999b20c6d25e3192f142f081b93d01f07b9d787e99664b169dba2700
+      SOURCE_VFY=sha256:550ba750239fd75b7e52c9877565cabffef506bbf6d7f6f17b9700dee56c720f
         WEB_SITE=http://sources.redhat.com/lvm2
          ENTERED=20040511
-         UPDATED=20190616
+         UPDATED=20181112
            SHORT="Logical volume manager"
            PSAFE=no
 LUNAR_RESTART_SERVICES=off

--- a/filesys/lvm2/POST_INSTALL
+++ b/filesys/lvm2/POST_INSTALL
@@ -1,1 +1,0 @@
-rm -fr $BUILD_DIRECTORY/LVM2-initramfs


### PR DESCRIPTION
Please try this bump again, but maybe as a series of smaller changes over a few days next time.  This bump made the ISO unbootable, which is a problem.