### PR TITLE
make: avoid using the guile depend.

### DIFF
--- a/devel/make/BUILD
+++ b/devel/make/BUILD
@@ -1,3 +1,5 @@
+OPTS+="--without-guile"
+
 default_config &&
 
 if ! make ${MAKES:-j${MAKES}}

--- a/devel/make/DEPENDS
+++ b/devel/make/DEPENDS
@@ -1,1 +1,2 @@
-optional_depends guile "--with-guile" "--without-guile" "for guile support"
+# updating libffi (guile depend) breaks make
+#optional_depends guile "--with-guile" "--without-guile" "for guile support"

--- a/devel/make/DETAILS
+++ b/devel/make/DETAILS
@@ -6,7 +6,7 @@
       SOURCE_VFY=sha256:d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589
         WEB_SITE=http://make.paulandlesley.org
          ENTERED=20010922
-         UPDATED=20181104
+         UPDATED=20191001
            SHORT="make generates executables and other non-source programs"
 
 cat << EOF


### PR DESCRIPTION
If libffi (guile depend) is updated it breaks the installed make.
