### PR TITLE
efivar: Add patches to get it to compile under gcc 9.

### DIFF
--- a/system/efivar/DETAILS
+++ b/system/efivar/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha256:74c52b4f479120fb6639e753e71163ba3f557a7a67c0be225593f9f05b253f36
         WEB_SITE=http://github.com/rhinstaller/efivar/
          ENTERED=20160717
-         UPDATED=20190312
+         UPDATED=20191011
            SHORT="Tools and library to manipulate EFI variables"
 
 cat << EOF

--- a/system/efivar/patch.d/b98ba8921010d03f46704a476c69861515deb1ca.patch
+++ b/system/efivar/patch.d/b98ba8921010d03f46704a476c69861515deb1ca.patch
@@ -1,0 +1,56 @@
+From b98ba8921010d03f46704a476c69861515deb1ca Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Mon, 7 Jan 2019 10:30:59 -0500
+Subject: [PATCH] dp.h: make format_guid() handle misaligned guid pointers
+ safely.
+
+GCC 9 adds -Werror=address-of-packed-member, which causes us to see the
+build error reported at
+ https://bugzilla.opensuse.org/show_bug.cgi?id=1120862 .
+
+That bug report shows us the following:
+
+In file included from dp.c:26:
+dp.h: In function 'format_vendor_helper':
+dp.h:120:37: error: taking address of packed member of 'struct <anonymous>' may result in an unaligned pointer value [-Werror=address-of-packed-member]
+  120 |  format_guid(buf, size, off, label, &dp->hw_vendor.vendor_guid);
+      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
+dp.h:74:25: note: in definition of macro 'format_guid'
+   74 |   _rc = efi_guid_to_str(guid, &_guidstr);   \
+      |                         ^~~~
+cc1: all warnings being treated as errors
+
+This patch makes format_guid() use a local variable as a bounce buffer
+in the case that the guid we're passed is aligned as chaotic neutral.
+
+Note that this only fixes this instance and there may be others that bz
+didn't show because it exited too soon, and I don't have a gcc 9 build
+in front of me right now.
+
+Signed-off-by: Peter Jones <pjones@redhat.com>
+---
+ src/dp.h | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/dp.h b/src/dp.h
+index aa4e390..20cb608 100644
+--- a/src/dp.h
++++ b/src/dp.h
+@@ -70,8 +70,15 @@
+ #define format_guid(buf, size, off, dp_type, guid) ({			\
+ 		int _rc;						\
+ 		char *_guidstr = NULL;					\
+-									\
+-		_rc = efi_guid_to_str(guid, &_guidstr);			\
++		efi_guid_t _guid;					\
++		const efi_guid_t * const _guid_p =			\
++			likely(__alignof__(guid) == sizeof(guid))	\
++				? guid					\
++				: &_guid;				\
++								        \
++		if (unlikely(__alignof__(guid) == sizeof(guid)))	\
++			memmove(&_guid, guid, sizeof(_guid));		\
++		_rc = efi_guid_to_str(_guid_p, &_guidstr);		\
+ 		if (_rc < 0) {						\
+ 			efi_error("could not build %s GUID DP string",	\
+ 				  dp_type);				\

--- a/system/efivar/patch.d/c3c553db85ff10890209d0fe48fb4856ad68e4e0.patch
+++ b/system/efivar/patch.d/c3c553db85ff10890209d0fe48fb4856ad68e4e0.patch
@@ -1,0 +1,168 @@
+From c3c553db85ff10890209d0fe48fb4856ad68e4e0 Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Thu, 21 Feb 2019 15:20:12 -0500
+Subject: [PATCH] Fix all the places -Werror=address-of-packed-member catches.
+
+This gets rid of all the places GCC 9's -Werror=address-of-packed-member
+flags as problematic.
+
+Fixes github issue #123
+
+Signed-off-by: Peter Jones <pjones@redhat.com>
+---
+ src/dp-message.c            |  6 ++++--
+ src/dp.h                    | 12 ++++--------
+ src/guid.c                  |  2 +-
+ src/include/efivar/efivar.h |  2 +-
+ src/ucs2.h                  | 27 +++++++++++++++++++--------
+ 5 files changed, 29 insertions(+), 20 deletions(-)
+
+diff --git a/src/dp-message.c b/src/dp-message.c
+index 3724e5f..9f96466 100644
+--- a/src/dp-message.c
++++ b/src/dp-message.c
+@@ -620,11 +620,13 @@ _format_message_dn(char *buf, size_t size, const_efidp dp)
+ 			  ) / sizeof(efi_ip_addr_t);
+ 		format(buf, size, off, "Dns", "Dns(");
+ 		for (int i=0; i < end; i++) {
+-			const efi_ip_addr_t *addr = &dp->dns.addrs[i];
++			efi_ip_addr_t addr;
++
++			memcpy(&addr, &dp->dns.addrs[i], sizeof(addr));
+ 			if (i != 0)
+ 				format(buf, size, off, "Dns", ",");
+ 			format_ip_addr(buf, size, off, "Dns",
+-				       dp->dns.is_ipv6, addr);
++				       dp->dns.is_ipv6, &addr);
+ 		}
+ 		format(buf, size, off, "Dns", ")");
+ 		break;
+diff --git a/src/dp.h b/src/dp.h
+index 20cb608..1f921d5 100644
+--- a/src/dp.h
++++ b/src/dp.h
+@@ -71,13 +71,9 @@
+ 		int _rc;						\
+ 		char *_guidstr = NULL;					\
+ 		efi_guid_t _guid;					\
+-		const efi_guid_t * const _guid_p =			\
+-			likely(__alignof__(guid) == sizeof(guid))	\
+-				? guid					\
+-				: &_guid;				\
+-								        \
+-		if (unlikely(__alignof__(guid) == sizeof(guid)))	\
+-			memmove(&_guid, guid, sizeof(_guid));		\
++		const efi_guid_t * const _guid_p = &_guid;		\
++									\
++		memmove(&_guid, guid, sizeof(_guid));			\
+ 		_rc = efi_guid_to_str(_guid_p, &_guidstr);		\
+ 		if (_rc < 0) {						\
+ 			efi_error("could not build %s GUID DP string",	\
+@@ -86,7 +82,7 @@
+ 			_guidstr = onstack(_guidstr,			\
+ 					   strlen(_guidstr)+1);		\
+ 			_rc = format(buf, size, off, dp_type, "%s",	\
+-				     _guidstr);	\
++				     _guidstr);				\
+ 		}							\
+ 		_rc;							\
+ 	})
+diff --git a/src/guid.c b/src/guid.c
+index 306c9ff..3156b3b 100644
+--- a/src/guid.c
++++ b/src/guid.c
+@@ -31,7 +31,7 @@
+ extern const efi_guid_t efi_guid_zero;
+ 
+ int NONNULL(1, 2) PUBLIC
+-efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b)
++efi_guid_cmp(const void * const a, const void * const b)
+ {
+ 	return memcmp(a, b, sizeof (efi_guid_t));
+ }
+diff --git a/src/include/efivar/efivar.h b/src/include/efivar/efivar.h
+index 316891c..ad6449d 100644
+--- a/src/include/efivar/efivar.h
++++ b/src/include/efivar/efivar.h
+@@ -128,7 +128,7 @@ extern int efi_symbol_to_guid(const char *symbol, efi_guid_t *guid)
+ 
+ extern int efi_guid_is_zero(const efi_guid_t *guid);
+ extern int efi_guid_is_empty(const efi_guid_t *guid);
+-extern int efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b);
++extern int efi_guid_cmp(const void * const a, const void * const b);
+ 
+ /* import / export functions */
+ typedef struct efi_variable efi_variable_t;
+diff --git a/src/ucs2.h b/src/ucs2.h
+index dbb5900..edd8367 100644
+--- a/src/ucs2.h
++++ b/src/ucs2.h
+@@ -23,16 +23,21 @@
+ 	(((val) & ((mask) << (shift))) >> (shift))
+ 
+ static inline size_t UNUSED
+-ucs2len(const uint16_t * const s, ssize_t limit)
++ucs2len(const void *vs, ssize_t limit)
+ {
+ 	ssize_t i;
+-	for (i = 0; i < (limit >= 0 ? limit : i+1) && s[i] != (uint16_t)0; i++)
++	const uint16_t *s = vs;
++	const uint8_t *s8 = vs;
++
++	for (i = 0;
++	     i < (limit >= 0 ? limit : i+1) && s8[0] != 0 && s8[1] != 0;
++	     i++, s8 += 2, s++)
+ 		;
+ 	return i;
+ }
+ 
+ static inline size_t UNUSED
+-ucs2size(const uint16_t * const s, ssize_t limit)
++ucs2size(const void *s, ssize_t limit)
+ {
+ 	size_t rc = ucs2len(s, limit);
+ 	rc *= sizeof (uint16_t);
+@@ -69,10 +74,11 @@ utf8size(uint8_t *s, ssize_t limit)
+ }
+ 
+ static inline unsigned char * UNUSED
+-ucs2_to_utf8(const uint16_t * const chars, ssize_t limit)
++ucs2_to_utf8(const void * const voidchars, ssize_t limit)
+ {
+ 	ssize_t i, j;
+ 	unsigned char *ret;
++	const uint16_t * const chars = voidchars;
+ 
+ 	if (limit < 0)
+ 		limit = ucs2len(chars, -1);
+@@ -124,10 +130,12 @@ ucs2_to_utf8(const uint16_t * const chars, ssize_t limit)
+ }
+ 
+ static inline ssize_t UNUSED NONNULL(4)
+-utf8_to_ucs2(uint16_t *ucs2, ssize_t size, int terminate, uint8_t *utf8)
++utf8_to_ucs2(void *ucs2void, ssize_t size, int terminate, uint8_t *utf8)
+ {
+ 	ssize_t req;
+ 	ssize_t i, j;
++	uint16_t *ucs2 = ucs2void;
++	uint16_t val16;
+ 
+ 	if (!ucs2 && size > 0) {
+ 		errno = EINVAL;
+@@ -162,10 +170,13 @@ utf8_to_ucs2(uint16_t *ucs2, ssize_t size, int terminate, uint8_t *utf8)
+ 			val = utf8[i] & 0x7f;
+ 			i += 1;
+ 		}
+-		ucs2[j] = val;
++		val16 = val;
++		ucs2[j] = val16;
++	}
++	if (terminate) {
++		val16 = 0;
++		ucs2[j++] = val16;
+ 	}
+-	if (terminate)
+-		ucs2[j++] = (uint16_t)0;
+ 	return j;
+ };
+ 


### PR DESCRIPTION
From:

    https://github.com/rhboot/efivar/commit/b98ba8921010d03f46704a476c69861515deb1ca.patch
    https://github.com/rhboot/efivar/commit/c3c553db85ff10890209d0fe48fb4856ad68e4e0.patch

As reported in:

    https://github.com/rhboot/efivar/issues/127