### PR TITLE
dbus: Fix adding the "messagebus" user.

### DIFF
--- a/system/dbus/BUILD
+++ b/system/dbus/BUILD
@@ -25,7 +25,7 @@ default_build &&
 
 # The following used to be in POST_INSTALL but the service wasn't starting
 # on FIRST install due to the lack of existing /var/lib/dbus
-add_priv_user messagebus:messagebus -d /dev/null -s /bin/false &&
+add_priv_user messagebus:messagebus -d /dev/null -s /usr/bin/false &&
 mkdir -p /var/run/dbus &&
 chown -R messagebus:messagebus /var/run/dbus &&
 


### PR DESCRIPTION
It seems that the latest version of shadow doesn't let you add
users with an invalid shell.  The `false` binary is in /usr/bin,
not in /bin.