### PR TITLE
lvm2: Changing where service and socket points to clear this error fr…

### DIFF
--- a/filesys/lvm2/systemd.d/dm-event.service
+++ b/filesys/lvm2/systemd.d/dm-event.service
@@ -10,7 +10,7 @@ Type=forking
 ExecStart=/usr/sbin/dmeventd
 ExecReload=/usr/sbin/dmeventd -R
 Environment=SD_ACTIVATION=1
-PIDFile=/var/run/dmeventd.pid
+PIDFile=/run/dmeventd.pid
 OOMScoreAdjust=-1000
 
 [Install]

--- a/filesys/lvm2/systemd.d/dm-event.socket
+++ b/filesys/lvm2/systemd.d/dm-event.socket
@@ -3,8 +3,8 @@ Description=Device-mapper event daemon FIFOs
 DefaultDependencies=no
 
 [Socket]
-ListenFIFO=/var/run/dmeventd-server
-ListenFIFO=/var/run/dmeventd-client
+ListenFIFO=/run/dmeventd-server
+ListenFIFO=/run/dmeventd-client
 SocketMode=0600
 
 [Install]


### PR DESCRIPTION
…om the journal;

Jan 04 06:27:48 sidney systemd[1]: /usr/lib/systemd/system/dm-event.service:13: PIDFile= references a path below legacy directory /var/run/, updating /var/run/>
Jan 04 06:27:48 sidney systemd[1]: /usr/lib/systemd/system/dm-event.socket:6: ListenFIFO= references a path below legacy directory /var/run/, updating /var/run>
Jan 04 06:27:48 sidney systemd[1]: /usr/lib/systemd/system/dm-event.socket:7: ListenFIFO= references a path below legacy directory /var/run/, updating /var/run>