### PR TITLE
python-setuptools: Roll back to a previous version.

### DIFF
--- a/python/python-setuptools/DETAILS
+++ b/python/python-setuptools/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python-setuptools
-         VERSION=42.0.2
+         VERSION=41.6.0
           SOURCE=setuptools-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/pypa/setuptools/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:24d07d1053431afb40ba9c82cc00f08259a1e4240098358c5da9c13dc49b640d
+      SOURCE_VFY=sha256:1b91aa309ffa43656774984557d62fae1fded0491a16ba8084b21c92cd5ad093
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/setuptools-$VERSION
         WEB_SITE=http://packages.python.org/distribute/
          ENTERED=20071221
-         UPDATED=20191222
+         UPDATED=20200120
             TYPE=python3
         REPLACES=setuptools-3
            SHORT="A simplified packaging system for Python 3.x"


### PR DESCRIPTION
This rolls back commit 24f0710d359eba5284f9565d48fa21fd8637130d.

In version 42.0, python-setuptools installs Python code in a way that
installwatch doesn't see.

This rolls that back so that we can have working dailies while we work
on fixing installwatch so it spots setuptools's nonsense.