### PR TITLE
meson: Fix the build to use default_python3_build.

### DIFF
--- a/devel/meson/BUILD
+++ b/devel/meson/BUILD
@@ -1,6 +1,4 @@
-prepare_install &&
-
-python3 setup.py install --optimize=1 --root=/ &&
+default_python3_build &&
 
 for _f in data/syntax-highlighting/vim/*/*; do
    install -Dt /usr/share/vim/vimfiles/$(basename "$(dirname "$_f")") -m644 $_f


### PR DESCRIPTION
I did this because I fixed default_python3_build so that it doesn't
trust the handiwork of setuptools as much any more, and has it install
into a DESTDIR instead.