### PR TITLE
lunar: Version bump to 39.

### DIFF
--- a/system/lunar/DETAILS
+++ b/system/lunar/DETAILS
@@ -1,12 +1,12 @@
           MODULE=lunar
-         VERSION=38
+         VERSION=39
           SOURCE=$MODULE-$VERSION.tar.bz2
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
       SOURCE_URL=http://lunar-linux.org/lunar/lunar/
-      SOURCE_VFY=sha256:2cadb3325b395cb2d3276e5febf08190855a70de96de2c8df8fe3429147ccd25
+      SOURCE_VFY=sha256:3d494a9a9eb73e6b709e8fbf4263373664d6721ffc299f09200029aacd96ec29
         WEB_SITE=http://lunar-linux.org/
          ENTERED=20020218
-         UPDATED=20200208
+         UPDATED=20200227
            SHORT="lunar contains the package management tools for Lunar-Linux."
 USE_WRAPPERS=off
 cat << EOF


### PR DESCRIPTION
This fixes the broken ISO (thanks to bad_flags, ONCE AGAIN), and adds some code to deal with obsolete modules (which I'm not sure is actually used yet).