### PR TITLE
kernel.org-hosted modules: Change download URL

### DIFF
--- a/crypto/cryptsetup/DETAILS
+++ b/crypto/cryptsetup/DETAILS
@@ -1,7 +1,7 @@
           MODULE=cryptsetup
          VERSION=2.3.1
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://www.kernel.org/pub/linux/utils/cryptsetup/v${VERSION%.*}
+      SOURCE_URL=http://mirrors.kernel.org/pub/linux/utils/cryptsetup/v${VERSION%.*}
       SOURCE_VFY=sha256:92aba4d559a2cf7043faed92e0f22c5addea36bd63f8c039ba5a8f3a159fe7d2
         WEB_SITE=http://code.google.com/p/cryptsetup
          ENTERED=20050309

--- a/libs/libcap/DETAILS
+++ b/libs/libcap/DETAILS
@@ -1,7 +1,7 @@
           MODULE=libcap
          VERSION=2.31
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/
+      SOURCE_URL=http://mirrors.kernel.org/pub/linux/libs/security/linux-privs/libcap2/
       SOURCE_VFY=sha256:c6088de41e1c97fa8047e2e7de0e4ee0cd13e6cc16538022230ae76727a87c46
         WEB_SITE=http://www.kernel.org/pub/linux/libs/security/linux-privs
          ENTERED=20040906

--- a/net/iproute2/DETAILS
+++ b/net/iproute2/DETAILS
@@ -1,7 +1,7 @@
           MODULE=iproute2
          VERSION=5.5.0
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=http://www.kernel.org/pub/linux/utils/net/$MODULE/
+      SOURCE_URL=http://mirrors.kernel.org/pub/linux/utils/net/$MODULE/
       SOURCE_VFY=sha256:bac543435cac208a11db44c9cc8e35aa902befef8750594654ee71941c388f7b
         WEB_SITE=http://www.linuxfoundation.org/collaborate/workgroups/networking/$MODULE/
          ENTERED=20021106


### PR DESCRIPTION
URLs that start at "https://www.kernel.org/" redirect via
"https://mirrors.edge.kernel.org/" which then (theoretically)
redirects on to "https://mirrors.kernel.org", which currently
has an expired SSL certificate.

So skip all the redirecting and just start at "mirrors.kernel.org".