### PR TITLE
Revert "ncurses: version bumped to 6.2."

### DIFF
--- a/libs/ncurses/DETAILS
+++ b/libs/ncurses/DETAILS
@@ -1,12 +1,12 @@
           MODULE=ncurses
-         VERSION=6.2
+         VERSION=6.1
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.gnu.org/pub/gnu/$MODULE
-      SOURCE_VFY=sha256:30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d
+      SOURCE_VFY=sha256:aa057eeeb4a14d470101eff4597d5833dcef5965331be3528c08d99cebaa0d17
         WEB_SITE=http://www.gnu.org/software/ncurses/ncurses.html
          ENTERED=20010922
-         UPDATED=20200213
+         UPDATED=20180130
            SHORT="Displays and updates text on text-only terminals"
            PSAFE=no
 


### PR DESCRIPTION
This reverts commit e37a936198ba39516ec3863c18b9d191fea4978d.

bumping ncurses nearly always causes the daily to fail, and this time is
no exception.