### PR TITLE
remove gcc version from plugin

### DIFF
--- a/compilers/gcc/DETAILS
+++ b/compilers/gcc/DETAILS
@@ -7,7 +7,7 @@
       SOURCE_VFY=sha256:71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
         WEB_SITE=http://gcc.gnu.org/
          ENTERED=20020628
-         UPDATED=20200313
+         UPDATED=20200325
            SHORT="GNU compiler collection"
 
 cat << EOF

--- a/compilers/gcc/plugin.d/optimize-gcc.plugin
+++ b/compilers/gcc/plugin.d/optimize-gcc.plugin
@@ -1,5 +1,5 @@
 #
-# gcc-9..x compiler optimizations plugin
+# gcc compiler optimizations plugin
 #
 
 compiler_gcc_optimize_defaults()
@@ -10,18 +10,18 @@ compiler_gcc_optimize_defaults()
   CPU=$(arch | sed 's;_;-;')
 }
 
-plugin_compiler_gcc_9_2_optimize()
+plugin_compiler_gcc_optimize()
 {
-  if [ "${LUNAR_COMPILER:-GCC_9_2}" != "GCC_9_2" ]; then
+  if [ "${LUNAR_COMPILER:-GCC}" != "GCC" ]; then
     return 2
   fi
 
-  debug_msg "plugin_compiler_gcc_9_2_optimize($@)"
+  debug_msg "plugin_compiler_gcc_optimize($@)"
 
   compiler_gcc_optimize_defaults
 
-  if [ -f /etc/lunar/local/optimizations.GCC_9_2 ]; then
-    . /etc/lunar/local/optimizations.GCC_9_2
+  if [ -f /etc/lunar/local/optimizations.GCC ]; then
+    . /etc/lunar/local/optimizations.GCC
   fi
 
   # some local macro's
@@ -170,17 +170,17 @@ plugin_compiler_gcc_9_2_optimize()
 }
 
 
-plugin_compiler_gcc_9_2_menu()
+plugin_compiler_gcc_menu()
 {
   # The main code calls this function WITHOUT $1 to find out which
   # compiler optimization plugins exist. It then returns the plugin
   # identifier which can be saved in $LUNAR_COMPILER as the user's
   # choice for COMPILERS
   if [ -z "$1" ]; then
-    echo "GCC_9_2"
-    echo "GNU C Compiler suite version 9.2.x"
+    echo "GCC"
+    echo "GNU C Compiler suite"
     return 2
-  elif [ "$1" != "GCC_9_2" ]; then
+  elif [ "$1" != "GCC" ]; then
     # we don't display anything when the user selected a
     # different menu
     return 2
@@ -209,7 +209,7 @@ plugin_compiler_gcc_9_2_menu()
   save_optimizations()
   {
     debug_msg "save_optimizations($@)"
-    cat >/etc/lunar/local/optimizations.GCC_9_2  <<EOF
+    cat >/etc/lunar/local/optimizations.GCC <<EOF
 CPU=$CPU
 CPUTUNE=$CPUTUNE
 BOPT=$BOPT
@@ -223,8 +223,8 @@ EOF
 
   compiler_gcc_optimize_defaults
 
-  if [ -f /etc/lunar/local/optimizations.GCC_9_2 ]; then
-    . /etc/lunar/local/optimizations.GCC_9_2
+  if [ -f /etc/lunar/local/optimizations.GCC ]; then
+    . /etc/lunar/local/optimizations.GCC
   fi
 
   export IFS=$'\t\n'
@@ -234,7 +234,7 @@ EOF
 
   while true; do
     unset OPTIONS
-    IS_DEFAULT=$([ "$(get_local_config LUNAR_COMPILER)" == "GCC_9_2" ] && echo DEFAULT || get_local_config LUNAR_COMPILER)
+    IS_DEFAULT=$([ "$(get_local_config LUNAR_COMPILER)" == "GCC" ] && echo DEFAULT || get_local_config LUNAR_COMPILER)
     DEFAULT=${CHOICE:-safe}
     CHOICE=`$DIALOG --title "$TITLE" --ok-label "Select" --cancel-label "Close" --default-item "$DEFAULT" --item-help --menu "" 0 0 0 $(
       echo "default"
@@ -286,8 +286,8 @@ EOF
       case $CHOICE in
         default)
           if [ "$IS_DEFAULT" != "DEFAULT" ]; then
-            set_local_config LUNAR_COMPILER GCC_9_2
-            $DIALOG --msgbox "Gcc 9.2 is now the default compiler!" 6 60
+            set_local_config LUNAR_COMPILER GCC
+            $DIALOG --msgbox "GCC is now the default compiler!" 6 60
           fi
           ;;
         safe)
@@ -691,5 +691,5 @@ EOF
 }
 
 
-plugin_register BUILD_BUILD plugin_compiler_gcc_9_2_optimize
-plugin_register OPTIMIZE_MENU plugin_compiler_gcc_9_2_menu
+plugin_register BUILD_BUILD plugin_compiler_gcc_optimize
+plugin_register OPTIMIZE_MENU plugin_compiler_gcc_menu


### PR DESCRIPTION
This was mainly a relict from times when it made sense to have different GCC versions around.

From now on, we have to make sure not to add backward incompatible default options to the plugin though,
as these would affect the previously installed version during the upgrade.