### PR TITLE
openssh: Removing StandardOutput from the service files for this reason;

### DIFF
--- a/crypto/openssh/DETAILS
+++ b/crypto/openssh/DETAILS
@@ -7,7 +7,7 @@
       SOURCE_VFY=sha256:f2befbe0472fe7eb75d23340eb17531cb6b3aac24075e2066b41f814e12387b2
         WEB_SITE=http://www.openssh.com/
          ENTERED=20010922
-         UPDATED=20200719
+         UPDATED=20200807
            SHORT="Client and server for encrypted remote logins and file transfers"
 
 cat << EOF

--- a/crypto/openssh/systemd.d/sshd.service
+++ b/crypto/openssh/systemd.d/sshd.service
@@ -8,7 +8,6 @@ ExecStart=/usr/sbin/sshd -D
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=always
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/crypto/openssh/systemd.d/sshd@.service
+++ b/crypto/openssh/systemd.d/sshd@.service
@@ -6,7 +6,6 @@ After=sshd-keys.service
 ExecStart=-/usr/sbin/sshd -i
 ExecReload=/usr/bin/kill -HUP $MAINPID
 StandardInput=socket
-StandardError=syslog
 
 [Install]
 WantedBy=network.target


### PR DESCRIPTION
Standard output type syslog is obsolete, automatically updating to journal.
Please update your unit file, and consider removing the setting altogether.