### PR TITLE
disable sse for gnu-efi

### DIFF
--- a/libs/gnu-efi/BUILD
+++ b/libs/gnu-efi/BUILD
@@ -1,3 +1,6 @@
+# upstream compiles with -mno-sse
+bad_flags -mfpmath=sse -mfpmath=both &&
+
 if [[ "$(arch)" == "x86_64" ]]; then
   EFI_ARCH=x86_64
 else


### PR DESCRIPTION
Fix module compilation. Upstream requires `-mno-sse` and compiles with -Werror.