### PR TITLE
elfutils: Disable debuginfod, and also disable libdebuginfod.

### DIFF
--- a/libs/elfutils/BUILD
+++ b/libs/elfutils/BUILD
@@ -1,6 +1,7 @@
 # We need to add this program prefix else its binaries will conflict with binutils
 OPTS+=" --program-prefix=eu- \
         --disable-debuginfod \
+        --disable-libdebuginfod \
         --enable-deterministic-archives"
 
 default_build


### PR DESCRIPTION
Apparently these are separate things and need to be explicitly disabled
separately.

Also probably a better way to deal with this would be to move all of
that into the optional-dependencies section of DEPENDS.