### PR TITLE
python: deleting the rm -r Modules/_decimal/libmpdec in PRE_BUILD. No…

### DIFF
--- a/python/python/DETAILS
+++ b/python/python/DETAILS
@@ -6,7 +6,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/Python-$VERSION
       SOURCE_VFY=sha256:015115023c382eb6ab83d512762fe3c5502fa0c6c52ffebc4831c4e1a06ffc49
         WEB_SITE=http://www.python.org
          ENTERED=20121013
-         UPDATED=20200722
+         UPDATED=20201219
         REPLACES=Python-3
            SHORT="Interpreted, interactive, object-oriented programming language"
 

--- a/python/python/PRE_BUILD
+++ b/python/python/PRE_BUILD
@@ -7,4 +7,3 @@ sed -i -e "s|^#.* /usr/local/bin/python|#!/usr/bin/python|" Lib/cgi.py &&
 # Ensure that we link against system libraries
 rm -rf Modules/{expat,zlib} &&
 rm -rf Modules/_ctypes/{darwin,libffi}*
-rm -r Modules/_decimal/libmpdec


### PR DESCRIPTION
… reason

not to use the tarball version for now and requires a switch to use system
provided mpdecimal.