### PR TITLE
[fix] util-linux: allow mount helpers in /usr/sbin

### DIFF
--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -11,7 +11,7 @@ OPTS+=" --enable-agetty     \
         --enable-write      \
         --disable-kill      \
         --disable-static    \
-        --enable-fs-paths-extra=/usr/bin"
+        --enable-fs-paths-extra=/usr/bin:/usr/sbin"
 
 default_config &&
 make ${MAKES:+-j${MAKES}} &&

--- a/utils/util-linux/DETAILS
+++ b/utils/util-linux/DETAILS
@@ -5,7 +5,7 @@
      SOURCE_VFY=sha256:9e4b1c67eb13b9b67feb32ae1dc0d50e08ce9e5d82e1cccd0ee771ad2fa9e0b1
         WEB_SITE=http://freecode.com/projects/util-linux
          ENTERED=20010922
-         UPDATED=20200723
+         UPDATED=20210110
            SHORT="Essential utilities for any Linux box"
 
 cat << EOF


### PR DESCRIPTION
mount.fuse3, mount.sshfs, and mount.crypt (pam_mount) install to /usr/sbin.

Some recent change broke my pam_mount setup that mounts my home folder upon login.
After two hours of debugging I figured out that the defaults call `mount -t crypt`
and expect the `mount.crypt` helper to be called.