### PR TITLE
Binutils rollback to 2.34

### DIFF
--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -1,12 +1,12 @@
           MODULE=binutils
-         VERSION=2.35.1
+         VERSION=2.34
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:a8dfaae8cbbbc260fc1737a326adca97b5d4f3c95a82f0af1f7455ed1da5e77b
+      SOURCE_VFY=sha256:53537d334820be13eeb8acb326d01c7c81418772d626715c7ae927a7d401cab3
         WEB_SITE=http://sources.redhat.com/binutils
          ENTERED=20010922
-         UPDATED=20200920
+         UPDATED=20200201
            SHORT="An essential collection of binary utilities"
 
 cat << EOF

--- a/libs/mpfr/DETAILS
+++ b/libs/mpfr/DETAILS
@@ -1,11 +1,11 @@
           MODULE=mpfr
-         VERSION=4.0.2
+         VERSION=4.1.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=http://www.mpfr.org/$MODULE-$VERSION/
-      SOURCE_VFY=sha256:1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a
+      SOURCE_VFY=sha256:0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
         WEB_SITE=http://www.mpfr.org
          ENTERED=20070111
-         UPDATED=20190203
+         UPDATED=20200811
            SHORT="C library for multiple-precision floating-point computations"
 
 cat << EOF


### PR DESCRIPTION
This undoes the version bump to 2.35.1, which broke efivar and thus the daily ISO.

Let's find a patch to fix efivar (or hope for a new release) and then bump again.