### PR TITLE
Libidn2 fix prebuild

### DIFF
--- a/libs/libidn2/DEPENDS
+++ b/libs/libidn2/DEPENDS
@@ -1,7 +1,4 @@
 depends libunistring
 
 # broken
-#optional_depends gtk-doc \
-#                 "--enable-gtk-doc" \
-#                 "--disable-gtk-doc" \
-#                 "for building documentation"
+optional_depends gtk-doc "" "" "for building documentation"

--- a/libs/libidn2/PRE_BUILD
+++ b/libs/libidn2/PRE_BUILD
@@ -1,3 +1,7 @@
+GTKDOCIZE=$(type -p gtkdocize)
+GTKDOCIZE=${GTKDOCIZE:-/usr/bin/true}
+export GTKDOCIZE
+
 default_pre_build &&
 
 autoreconf -fvi


### PR DESCRIPTION
Libidn2: Fix the prebuild to deal with both the presence and absence of gtk-doc.