### PR TITLE
openssl: Add BUILD.x86_64

### DIFF
--- a/crypto/openssl/BUILD.x86_64
+++ b/crypto/openssl/BUILD.x86_64
@@ -7,6 +7,7 @@ WANT_VERSION= download_module wget &&
          shared \
          no-ssl3 \
          no-ssl3-method \
+         enable-ec_nistp_64_gcc_128 \
          "-Wa,--noexecstack" \
          $OPTS
 


### PR DESCRIPTION
It turns out that 128-bit integers are only available in gcc on 64-bit
systems, so asking for openssl features that depend on having 128-bit
integers makes the build fail on i686 systems.