### PR TITLE
openssl: Add 128bit-integer-based option based on arch

### DIFF
--- a/crypto/openssl/BUILD
+++ b/crypto/openssl/BUILD
@@ -7,7 +7,7 @@ WANT_VERSION= download_module wget &&
          shared \
          no-ssl3 \
          no-ssl3-method \
-         enable-ec_nistp_64_gcc_128 \
+         $(arch | grep -q x86_64 && echo enable-ec_nistp_64_gcc_128) \
          "-Wa,--noexecstack" \
          $OPTS
 


### PR DESCRIPTION
This instead of adding a BUILD.x86_64 file, which is apparently too
clunky.