### PR TITLE
lvm2: Fix build for gcc 10.2 on i686

### DIFF
--- a/filesys/lvm2/BUILD
+++ b/filesys/lvm2/BUILD
@@ -1,6 +1,8 @@
 if ! [[ $(arch) == x86_64 ]]; then
   CFLAGS+=" -fPIE " &&
   LDFLAGS+=" -pie "
+  sedit 's/CLDFLAGS.*-Wl,-z,relro/& -shared/' libdm/make.tmpl.in
+  sedit 's/CLDFLAGS.*-Wl,-z,relro/& -shared/' make.tmpl.in
 fi
 
 if module_installed systemd; then


### PR DESCRIPTION
For some reason, gcc 10.2 forgets about the -shared flag if it's too
early on the command line, but only on i686 builds. This ugly hack adds
an extra "-shared" later on so that it remembers what it was supposed to
be doing, so that lvm2 can build in a 32-bit environment.