### PR TITLE
ccache: An improvement over 8700c2419cc7d0afd07ce4d8701849797e0a4bf3.

### DIFF
--- a/utils/ccache/DEPENDS
+++ b/utils/ccache/DEPENDS
@@ -1,1 +1,3 @@
 depends zlib
+depends zstd
+depends cmake

--- a/utils/ccache/DETAILS
+++ b/utils/ccache/DETAILS
@@ -1,13 +1,13 @@
           MODULE=ccache
-         VERSION=3.7.11
+         VERSION=4.3
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://github.com/ccache/ccache/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:8d450208099a4d202bd7df87caaec81baee20ce9dd62da91e9ea7b95a9072f68
+      SOURCE_VFY=sha256:504a0f2184465c306826f035b4bc00bae7500308d6af4abbfb50e33a694989b4
         WEB_SITE=http://ccache.samba.org
+            TYPE=cmake
          ENTERED=20020701
-         UPDATED=20200723
+         UPDATED=20210615
            SHORT="A compiler cache"
-
 cat << EOF
 ccache is a compiler cache. It acts as a caching pre-processor to C/C++
 compilers, using the -E compiler switch and a hash to detect when a

--- a/utils/ccache/PRE_BUILD
+++ b/utils/ccache/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build
+
+OPTS+=" -DENABLE_DOCUMENTATION=OFF \
+        -DUSE_CCACHE=OFF"


### PR DESCRIPTION
The issue was not finding /usr/bin/ccache in the final install phase.

Adding a PRE_BUILD to disable using existing /usr/bin/ccache resovled it.
Its also PSAFE.