### PR TITLE
linux-firmware: Bump to 20210616. The DETAILS said to use master, sai…

### DIFF
--- a/kernel/linux-firmware/DETAILS
+++ b/kernel/linux-firmware/DETAILS
@@ -2,12 +2,12 @@
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
 # git archive --format=tar --prefix linux-firmware-$(date +%Y%m%d)/ master | xz -9 > linux-firmware-$(date +%Y%m%d).tar.xz
           MODULE=linux-firmware
-         VERSION=20200906
+         VERSION=20210616
           SOURCE=${MODULE}-${VERSION}.tar.xz
 # This is a temporary fix until the kernel.org folks get things squared away
       SOURCE_URL=$MIRROR_URL
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:e071755e11a65c01ae898ddc10a7dea15e0ba2afb11e87bce78ed480642afb17
+      SOURCE_VFY=sha256:c23a1954bb340aafa3c1b3b9a2b47222deef8f68d6b99502c7c6b9a45628cf34
         WEB_SITE="http://www.kernel.org/pub/linux/kernel/people/dwmw2/firmware/"
          ENTERED=20100925
          UPDATED=20200906


### PR DESCRIPTION
…d it wasn't a git

repository. Used HEAD instead.