### PR TITLE
meson: Rolback PR #2796

### DIFF
--- a/devel/meson/DEPENDS
+++ b/devel/meson/DEPENDS
@@ -1,2 +1,3 @@
+depends rsync
 depends python-setuptools
 depends ninja


### PR DESCRIPTION
There is literally no reason for meson to have a hard dependency on
rsync. Do the devs not know about the cp command?