### PR TITLE
rolling-back 2796: meson: rsync isn't in moonbase-core (yet)

### DIFF
--- a/devel/meson/DEPENDS
+++ b/devel/meson/DEPENDS
@@ -1,3 +1,2 @@
-depends rsync
 depends python-setuptools
 depends ninja


### PR DESCRIPTION
I'm going to keep meson rolled back until I figure out why on earth it
seems to think it depends on rsync (I have a feeling it doesn't).

Until then, adding the rsync dependency has unfortunately done an
excellent job of breaking the dailies. Sorry!