### PR TITLE
ntfs-3g: Make the answer for the gnutls dependency default to "n"

### DIFF
--- a/filesys/ntfs-3g/DEPENDS
+++ b/filesys/ntfs-3g/DEPENDS
@@ -2,4 +2,4 @@ optional_depends attr       "--enable-xattr-mappings" "--disable-xattr-mappings"
 optional_depends acl        "--enable-posix-acls "    "--disable-posix-acls"       "For POSIX ACL support" n
 optional_depends util-linux "--with-uuid"             "--without-uuid"             "To generate DCE compliant UUIDs" y
 optional_depends fuse       "--with-fuse=external"    "--with-fuse=internal"       "If yes, use system provided fuse, else internal is used" n
-optional_depends gnutls     "--enable-crypto"         "--disable-crypto"           "For encrypted disk support" y
+optional_depends gnutls     "--enable-crypto"         "--disable-crypto"           "For encrypted disk support" n


### PR DESCRIPTION
Having it default to "y" breaks the ISO build, so let it be off by
default instead.