### PR TITLE
zlib: Version bump to 1.2.12

### DIFF
--- a/archive/zlib/DETAILS
+++ b/archive/zlib/DETAILS
@@ -1,12 +1,12 @@
 # update the minizip module too from other/archive
           MODULE=zlib
-         VERSION=1.2.11
+         VERSION=1.2.12
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=http://www.zlib.net/
-      SOURCE_VFY=sha256:c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+      SOURCE_VFY=sha256:91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
         WEB_SITE=http://www.zlib.net
          ENTERED=20010922
-         UPDATED=20170116
+         UPDATED=20220330
            SHORT="lossless data compression library"
 
 cat << EOF


### PR DESCRIPTION
This is a security update. For bonus points, they also deleted 1.2.11
from their site altogether, which means that if this isn't bumped, the
daily builds will fail altogether.