### PR TITLE
dbus: Stop trying to check for gtk-sharp

### DIFF
--- a/system/dbus/POST_INSTALL
+++ b/system/dbus/POST_INSTALL
@@ -1,9 +1,1 @@
-dbus-uuidgen --ensure=/etc/machine-id &&
-
-if ! module_installed gtk-sharp; then
-  message "${CYAN}You don't seem to have gtk-sharp installed"
-  message "and there's nothing wrong about that."
-  message "But if you were to compile mono bindings for dbus"
-  message "you have to install gtk-sharp first and recompile"
-  message "dbus afterwards.${DEFAULT_COLOR}"
-fi
+dbus-uuidgen --ensure=/etc/machine-id


### PR DESCRIPTION
It's been dead since 2018 at least