### PR TITLE
openssl: Version bump to 1.1.1o

### DIFF
--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -1,5 +1,5 @@
           MODULE=openssl
-         VERSION=1.1.1m
+         VERSION=1.1.1o
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=Makefile.openssl-certs
    SOURCE_URL[0]=http://www.openssl.org/source
@@ -8,11 +8,11 @@
    SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
    SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
+      SOURCE_VFY=sha256:9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
      SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
         WEB_SITE=http://www.openssl.org
          ENTERED=20010922
-         UPDATED=20211224
+         UPDATED=20220509
            PSAFE="no"
            SHORT="A library for providing encrypted transport layers"
 


### PR DESCRIPTION
Probably less scary than bumping it all the way to 3.0.3?
