### PR TITLE
lunar: version bumped to 42

### DIFF
--- a/system/lunar/DETAILS
+++ b/system/lunar/DETAILS
@@ -1,12 +1,12 @@
           MODULE=lunar
-         VERSION=41
+         VERSION=42
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
  SOURCE_URL_FULL=https://github.com/lunar-linux/lunar/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:4b80245eeb2a2b4f2fdafc2153cac2105a1583d7f9ba9396a29672ff8a034401
+      SOURCE_VFY=sha256:ba90e91e2952b78e559992b985033c8cc3bad70eab6057450d5896085274e2ba
         WEB_SITE=http://lunar-linux.org/
          ENTERED=20020218
-         UPDATED=20220213
+         UPDATED=20220703
            SHORT="lunar contains the package management tools for Lunar-Linux."
 USE_WRAPPERS=off
 


### PR DESCRIPTION
Changes:
- Do not trigger removal for held modules if the module was removed from moonbase
- Changed the logic of lin -R (resurrect), it will now check that there is a
  cache tarball available before removing the existing version
- lin will now check that there is enough free space (2GB default) available in
  $INSTALL_CACHE and $BUILD_DIRECTORY before starting the build
- Post removal; a big fundamental change in how lin installs and removes the
  module files. Previously files were removed during prepare_install, just
  before a module ran "make install". With this change only /etc files are
  removed/backed up during prepare_install, then make install just overwrites
  any existing files. During final_install() the current and previous
  install logs are checked for differences, and untouched files from the
  previous logs are removed. This means less issues for system critical updates
  such as glibc, where we can remove all hacks to trick the system where the
  libs are. NOTE: For now it's opt-in per module by using "DESTDIR_BUILD=on" in
  DETAILS.
- Added a few new global variables related to "strip". $STRIP_BINARIES,
  $STRIP_SHARED and $STRIP_STATIC. They can easily be used for default flags
  when manually using strip. These will later be used in a new auto-strip
  feature.

Other fixes:
- Removed deprecated documentation and references to theedge
- Added missing default variable KEEP_OBSOLETE_LIBS
- Fixed the non-working alias, download, mirror and integrity menus
- Fixed bad_flags to allow proper removal of any string
- Fixed a few issues with the python build types
- Removed some old files from protected list
- Return an error if the module appear to install zero files


Closes #2995 