### PR TITLE
libmnl: Adding a BUILD to disable doxygen. While not a problem on a f…

### DIFF
--- a/net/libmnl/BUILD
+++ b/net/libmnl/BUILD
@@ -1,0 +1,3 @@
+OPTS=" --without-doxygen"
+
+default_build


### PR DESCRIPTION
…resh install later on with

doxygen installed it will fail on doc creation with cp attempting to preserve times.