### PR TITLE
util-linux : version bump

### DIFF
--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -1,32 +1,11 @@
-OPTS+=" --enable-agetty     \
-        --enable-chfn-chsh  \
-        --enable-fsck       \
-        --enable-mesg       \
-        --enable-partx      \
-        --enable-rename     \
-        --enable-schedutils \
-        --enable-vipw       \
-        --enable-newgrp     \
-        --enable-write      \
-        --disable-kill      \
-        --disable-static    \
-        --enable-fs-paths-extra=/usr/bin:/usr/sbin"
+OPTS+="-Dstrip=true"
 
-default_config &&
-make ${MAKES:+-j${MAKES}} &&
-mkdir _pkg &&
-make install DESTDIR=$(cd _pkg && pwd) &&
-mv _pkg/sbin/sulogin _pkg/usr/sbin &&
-chmod 700 _pkg/usr/bin/wall &&
-chmod 4711 _pkg/usr/bin/{newgrp,ch{sh,fn}} &&
-if module_installed systemd; then
-  sedit '/ListenStream/ aRuntimeDirectory=uuidd' _pkg/usr/lib/systemd/system/uuidd.socket
-fi &&
-
-cd _pkg &&
+default_meson_build &&
 prepare_install &&
-find . -depth -print0 | cpio -0pdmuv / &&
-
+chmod 700 /usr/bin/wall &&
+chmod 4711 /usr/bin/{newgrp,ch{sh,fn}} &&
+mv /sbin/sulogin /usr/sbin &&
+sedit '/ListenStream/ aRuntimeDirectory=uuidd' /usr/lib/systemd/system/uuidd.socket &&
 install -g0 -o0 -m755 $SCRIPT_DIRECTORY/make-issue /usr/bin/make-issue &&
 install -Dm644 $SCRIPT_DIRECTORY/60-rfkill.rules /usr/lib/udev/rules.d/60-rfkill.rules &&
 ln -sf /usr/bin/last /usr/bin/lastb

--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -1,4 +1,5 @@
-OPTS+="-Dstrip=true"
+OPTS+="-Dstrip=true \
+      -Dbuild-kill=disabled"
 
 default_meson_build &&
 prepare_install &&

--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -5,7 +5,6 @@ default_meson_build &&
 prepare_install &&
 chmod 700 /usr/bin/wall &&
 chmod 4711 /usr/bin/{newgrp,ch{sh,fn}} &&
-mv /sbin/sulogin /usr/sbin &&
 sedit '/ListenStream/ aRuntimeDirectory=uuidd' /usr/lib/systemd/system/uuidd.socket &&
 install -g0 -o0 -m755 $SCRIPT_DIRECTORY/make-issue /usr/bin/make-issue &&
 install -Dm644 $SCRIPT_DIRECTORY/60-rfkill.rules /usr/lib/udev/rules.d/60-rfkill.rules &&

--- a/utils/util-linux/DEPENDS
+++ b/utils/util-linux/DEPENDS
@@ -3,6 +3,7 @@ depends shadow
 depends zlib
 depends findutils
 depends cpio
+depends libcap-ng
 
 optional_depends python  "" "" "for Python 3 support" y
 optional_depends Linux-PAM "" "" "for PAM support"

--- a/utils/util-linux/DEPENDS
+++ b/utils/util-linux/DEPENDS
@@ -4,7 +4,5 @@ depends zlib
 depends findutils
 depends cpio
 
-optional_depends python  "--with-python=3" "" "for Python 3 support" y
-optional_depends python2 "--with-python=2" "" "for Python 2 support" n
-
+optional_depends python  "" "" "for Python 3 support" y
 optional_depends Linux-PAM "" "" "for PAM support"

--- a/utils/util-linux/DETAILS
+++ b/utils/util-linux/DETAILS
@@ -1,12 +1,13 @@
           MODULE=util-linux
-         VERSION=2.37.2
+         VERSION=2.38
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$KERNEL_URL/pub/linux/utils/$MODULE/v${VERSION::4}
-     SOURCE_VFY=sha256:6a0764c1aae7fb607ef8a6dd2c0f6c47d5e5fd27aa08820abaad9ec14e28e9d9
+     SOURCE_VFY=sha256:6d111cbe4d55b336db2f1fbeffbc65b89908704c01136371d32aa9bec373eb64
         WEB_SITE=http://freecode.com/projects/util-linux
          ENTERED=20010922
-         UPDATED=20220215
+         UPDATED=20220803
            SHORT="Essential utilities for any Linux box"
+	    TYPE=meson
 
 cat << EOF
 Util-linux is a suite of essential utilities for any Linux system. Its primary


### PR DESCRIPTION
As discussed on IRC:
In it's present version, util-linux uses DESTDIR, and creates it's own /bin, /sbin & /lib directories if they're not present. This has no effect on a typical Lunar install, but will break a unified /usr build, which is planned for Lunar's future.

**BUILD:**
- all but one of the old OPTS are now defaults in util-linux, so they were replaced by a -Dstrip=true and -Dbuild-kill=disabled OPTS.

The old build commands did a lot:
1. compiled the code.
2. installed the code to a _pkg directory.
3. performed a cpio compression on the files.
4. made several chmod changes.
5. moved one file.
6. performed a sed change to another file based upon an if statement.
7. installed the code to the main filesystem.
8. copied two files from $SCRIPT_DIRECTORY to the main filesystem
9. make a symbolic link.

I've changed it to:

1. compile the code.
2. install the code to the main filesystem.
3. make the chmod changes to the files in their installed locations.
4. change the if statement to a direct sed operation - the if statement was searching for systemd, which is installed by default.
5. copy the two files from $SCRIPT_DIRECTORY.
6. make the symbolic link.

- The BUILD instructions are slightly reduced, and are easier to understand. The only loss is the cpio compression, but using the -Dstrip option has a similar (or better?) size saving.
- The single file being moved isn't necessary any more - it's installed in the desired spot by default.
- It also works on a unified /usr system without problems.

**DEPENDS:**
this version defaults to python 3, and doesn't support python 2.

**DETAILS:**
normal version bump changes