### PR TITLE
linux-firmware: version bumped to 20220809

### DIFF
--- a/kernel/linux-firmware/BUILD
+++ b/kernel/linux-firmware/BUILD
@@ -1,10 +1,42 @@
-(
+_DESTDIR=$SOURCE_DIRECTORY/__destdir
 
-  prepare_install &&
-  mkdir -p /lib/firmware  &&
-  cp -av * /lib/firmware &&
-  rm -f /lib/firmware/{GPL*,LICEN*,WHENCE} &&
+make DESTDIR="${_DESTDIR}" FIRMWAREDIR=/lib/firmware installcompress &&
 
-  gather_docs GPL* LICEN* WHENCE
+if [[ "$FW_NFP" != "y" ]]; then
+  rm -rf "$_DESTDIR/lib/firmware/netronome" &&
+  rm -f "$SOURCE_DIRECTORY/LICENSE.Netronome"
+fi &&
 
-) > $C_FIFO 2>&1
+if [[ "$FW_MELLANOX" != "y" ]]; then
+  rm -rf "$_DESTDIR/lib/firmware/mellanox"
+fi &&
+
+if [[ "$FW_MARVELL" != "y" ]]; then
+  rm -rf "$_DESTDIR"/lib/firmware/{libertas,mwl8k,mwlwifi,mrvl} &&
+  rm -f "$SOURCE_DIRECTORY"/LICENSE.{Marvell,NXP}
+fi &&
+
+if [[ "$FW_QCOM" != "y" ]]; then
+  rm -rf "$_DESTDIR"/lib/firmware/{qcom,a300_*} &&
+  rm -f "$SOURCE_DIRECTORY"/LICENSE.qcom
+fi &&
+
+if [[ "$FW_LIQUIDIO" != "y" ]]; then
+  rm -rf "$_DESTDIR"/lib/firmware/liquidio &&
+  rm -f "$SOURCE_DIRECTORY"/LICENSE.cavium_liquidio
+fi &&
+
+if [[ "$FW_QLOGIC" != "y" ]]; then
+  rm -rf "$_DESTDIR"/lib/firmware/{qlogic,qed,ql2???_*,c{b,t,t2}fw-*} &&
+  rm -f "$SOURCE_DIRECTORY"/LICENSE.{qla1280,qla2xxx}
+fi &&
+
+if [[ "$FW_BNX2X" != "y" ]]; then
+  rm -rf "$_DESTDIR"/lib/firmware/bnx2x*
+fi &&
+
+prepare_install &&
+
+cp -rf --remove-destination $_DESTDIR/* / &&
+
+gather_docs GPL* LICEN* WHENCE

--- a/kernel/linux-firmware/CONFIGURE
+++ b/kernel/linux-firmware/CONFIGURE
@@ -4,4 +4,4 @@ mquery FW_MARVELL "Install firmware for Marvell devices" y
 mquery FW_QCOM "Install firmware for Qualcomm SoCs" n
 mquery FW_LIQUIDIO "Install firmware for Cavium LiquidIO server adapters" n
 mquery FW_QLOGIC "Install firmware for QLogic devices" n
-mquery FW_BNX2X "Install firmware for QLogic devices" n
+mquery FW_BNX2X "Install firmware for Broadcom NetXtreme II 10Gb ethernet adapters" n

--- a/kernel/linux-firmware/CONFIGURE
+++ b/kernel/linux-firmware/CONFIGURE
@@ -1,0 +1,7 @@
+mquery FM_NFP "Install firmware for Netronome Flow Processors" n
+mquery FW_MELLANOX "Install firmware for Mellanox Spectrum switches" n
+mquery FW_MARVELL "Install firmware for Marvell devices" y
+mquery FW_QCOM "Install firmware for Qualcomm SoCs" n
+mquery FW_LIQUIDIO "Install firmware for Cavium LiquidIO server adapters" n
+mquery FW_QLOGIC "Install firmware for QLogic devices" n
+mquery FW_BNX2X "Install firmware for QLogic devices" n

--- a/kernel/linux-firmware/DETAILS
+++ b/kernel/linux-firmware/DETAILS
@@ -2,15 +2,15 @@
 # git clone git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
 # git archive --format=tar --prefix linux-firmware-$(date +%Y%m%d)/ main | xz -9 > linux-firmware-$(date +%Y%m%d).tar.xz
           MODULE=linux-firmware
-         VERSION=20220213
+         VERSION=20220809
           SOURCE=${MODULE}-${VERSION}.tar.xz
 # This is a temporary fix until the kernel.org folks get things squared away
       SOURCE_URL=$MIRROR_URL
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
-      SOURCE_VFY=sha256:0ea3e89165b91535379817a714ad7d0d31ec8c12ac21c217869c5b6315078a6e
+      SOURCE_VFY=sha256:6869241c0182f8ba6e7e42b2274e0e53c5ac3e03cdc710f4e4f7e5b1070e2dd7
         WEB_SITE="http://www.kernel.org/pub/linux/kernel/people/dwmw2/firmware/"
          ENTERED=20100925
-         UPDATED=20220213
+         UPDATED=20220809
            SHORT="Kernel firmware for various hardware"
 PSAFE=no
 

--- a/kernel/linux-firmware/PRE_BUILD
+++ b/kernel/linux-firmware/PRE_BUILD
@@ -1,0 +1,8 @@
+# Check that the kernel support compressed firmware
+if ! kernel_option_present CONFIG_FW_LOADER_COMPRESS; then
+  message "${MESSAGE_COLOR}The kernel option ${PROBLEM_COLOR}CONFIG_FW_LOADER_COMPRES${MESSAGE_COLOR} is not enabled.S${DEFAULT_COLOR}"
+  message "${MESSAGE_COLOR}Please reconfigure and rebuild your kernel. Then try installing linux-firmware again.${DEFAULT_COLOR}"
+  exit 1
+fi
+
+default_pre_build

--- a/kernel/linux-firmware/PRE_BUILD
+++ b/kernel/linux-firmware/PRE_BUILD
@@ -1,6 +1,6 @@
 # Check that the kernel support compressed firmware
 if ! kernel_option_present CONFIG_FW_LOADER_COMPRESS; then
-  message "${MESSAGE_COLOR}The kernel option ${PROBLEM_COLOR}CONFIG_FW_LOADER_COMPRES${MESSAGE_COLOR} is not enabled.S${DEFAULT_COLOR}"
+  message "${MESSAGE_COLOR}The kernel option ${PROBLEM_COLOR}CONFIG_FW_LOADER_COMPRES${MESSAGE_COLOR} is not enabled.${DEFAULT_COLOR}"
   message "${MESSAGE_COLOR}Please reconfigure and rebuild your kernel. Then try installing linux-firmware again.${DEFAULT_COLOR}"
   exit 1
 fi

--- a/kernel/linux-firmware/PRE_BUILD
+++ b/kernel/linux-firmware/PRE_BUILD
@@ -1,6 +1,6 @@
 # Check that the kernel support compressed firmware
 if ! kernel_option_present CONFIG_FW_LOADER_COMPRESS; then
-  message "${MESSAGE_COLOR}The kernel option ${PROBLEM_COLOR}CONFIG_FW_LOADER_COMPRES${MESSAGE_COLOR} is not enabled.${DEFAULT_COLOR}"
+  message "${MESSAGE_COLOR}The kernel option ${PROBLEM_COLOR}CONFIG_FW_LOADER_COMPRESS${MESSAGE_COLOR} is not enabled.${DEFAULT_COLOR}"
   message "${MESSAGE_COLOR}Please reconfigure and rebuild your kernel. Then try installing linux-firmware again.${DEFAULT_COLOR}"
   exit 1
 fi

--- a/kernel/linux-firmware/patch.d/0001-Add-support-for-compressing-firmware-in-copy-firmware.patch
+++ b/kernel/linux-firmware/patch.d/0001-Add-support-for-compressing-firmware-in-copy-firmware.patch
@@ -1,0 +1,123 @@
+From 7eec2b56f54c778d5bd6e7aea49ee03e3b76e769 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Fri, 22 Jan 2021 20:36:23 +0000
+Subject: [PATCH v2] Add support for compressing firmware in copy-firmware.sh
+
+As of kernel 5.3 there's initial support for loading compressed firmware.
+At this stage the only supported compression methis is "xz -C crc32" but
+this option brings significant benefits.
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+
+v2: quote filename for xz command
+
+ Makefile         |  4 ++++
+ copy-firmware.sh | 47 +++++++++++++++++++++++++++++++----------------
+ 2 files changed, 35 insertions(+), 16 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e1c362f..9a48471 100644
+--- a/Makefile
++++ b/Makefile
+@@ -11,3 +11,7 @@ check:
+ install:
+ 	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
+ 	./copy-firmware.sh $(DESTDIR)$(FIRMWAREDIR)
++
++installcompress:
++	mkdir -p $(DESTDIR)$(FIRMWAREDIR)
++	./copy-firmware.sh -C $(DESTDIR)$(FIRMWAREDIR)
+diff --git a/copy-firmware.sh b/copy-firmware.sh
+index 9b46b63..0dd2e5c 100755
+--- a/copy-firmware.sh
++++ b/copy-firmware.sh
+@@ -6,6 +6,7 @@
+ 
+ verbose=:
+ prune=no
++compress=no
+ 
+ while test $# -gt 0; do
+     case $1 in
+@@ -19,6 +20,11 @@ while test $# -gt 0; do
+             shift
+             ;;
+ 
++        -C | --compress)
++            compress=yes
++            shift
++            ;;
++
+         *)
+             if test "x$destdir" != "x"; then
+                 echo "ERROR: unknown command-line options: $@"
+@@ -31,40 +37,49 @@ while test $# -gt 0; do
+     esac
+ done
+ 
++if test "x$compress" = "xyes"; then
++    cmpxtn=.xz
++    grep '^File:' WHENCE | sed -e's/^File: *//g' -e's/"//g' | while read f; do
++       test -f "$f" || continue
++       $verbose "compressing $f"
++       xz -C crc32 "$f"
++    done
++fi
++
+ grep '^File:' WHENCE | sed -e's/^File: *//g' -e's/"//g' | while read f; do
+-    test -f "$f" || continue
+-    $verbose "copying file $f"
+-    install -d $destdir/$(dirname "$f")
+-    cp -d "$f" $destdir/"$f"
++    test -f "$f$cmpxtn" || continue
++    $verbose "copying file $f$cmpxtn"
++    install -d $destdir/$(dirname "$f$cmpxtn")
++    cp -d "$f$cmpxtn" $destdir/"$f$cmpxtn"
+ done
+ 
+ grep -E '^Link:' WHENCE | sed -e's/^Link: *//g' -e's/-> //g' | while read f d; do
+-    if test -L "$f"; then
+-        test -f "$destdir/$f" && continue
+-        $verbose "copying link $f"
+-        install -d $destdir/$(dirname "$f")
++    if test -L "$f$cmpxtn"; then
++        test -f "$destdir/$f$cmpxtn" && continue
++        $verbose "copying link $f$cmpxtn"
++        install -d $destdir/$(dirname "$f$cmpxtn")
+         cp -d "$f" $destdir/"$f"
+ 
+         if test "x$d" != "x"; then
+-            target=`readlink "$f"`
++            target=`readlink "$f$cmpxtn"`
+ 
+             if test "x$target" != "x$d"; then
+                 $verbose "WARNING: inconsistent symlink target: $target != $d"
+             else
+                 if test "x$prune" != "xyes"; then
+-                    $verbose "WARNING: unneeded symlink detected: $f"
++                    $verbose "WARNING: unneeded symlink detected: $f$cmpxtn"
+                 else
+-                    $verbose "WARNING: pruning unneeded symlink $f"
+-                    rm -f "$f"
++                    $verbose "WARNING: pruning unneeded symlink $f$cmpxtn"
++                    rm -f "$f$cmpxtn"
+                 fi
+             fi
+         else
+-            $verbose "WARNING: missing target for symlink $f"
++            $verbose "WARNING: missing target for symlink $f$cmpxtn"
+         fi
+     else
+-        $verbose "creating link $f -> $d"
+-        install -d $destdir/$(dirname "$f")
+-        ln -sf "$d" "$destdir/$f"
++        $verbose "creating link $f$cmpxtn -> $d$cmpxtn"
++        install -d $destdir/$(dirname "$f$cmpxtn")
++        ln -sf "$d$cmpxtn" "$destdir/$f$cmpxtn"
+     fi
+ done
+ 
+-- 
+2.29.2
+


### PR DESCRIPTION
Changes:
- Less commonly used firmware will default to not being installed
- All firmware is now xz compressed, requires
  CONFIG_FW_LOADER_COMPRESS to be enabled in the kernel