### PR TITLE
binutils: Bump to 2.39 and needed --sysconfdir=/etc in BUILD else it …

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -11,6 +11,7 @@ if [[ "$(arch)" == "i686" ]]; then
 fi &&
 
 ../configure --prefix=/usr    \
+             --sysconfdir=/etc   \
              --disable-gdb    \
              --disable-gdbserver \
              --disable-werror \

--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -1,12 +1,12 @@
           MODULE=binutils
-         VERSION=2.38
+         VERSION=2.39
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024
+      SOURCE_VFY=sha256:645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
         WEB_SITE=http://sources.redhat.com/binutils
          ENTERED=20010922
-         UPDATED=20220210
+         UPDATED=20220821
            SHORT="An essential collection of binary utilities"
 
 cat << EOF


### PR DESCRIPTION
…would install

gprofng.rc in /usr/etc.