### PR TITLE
python-setuptools: Why I seem to be the only one having issues with t…

### DIFF
--- a/python/python-setuptools/DETAILS
+++ b/python/python-setuptools/DETAILS
@@ -5,8 +5,8 @@
          VERSION=52.0.0
           SOURCE=setuptools-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/setuptools-$VERSION
- SOURCE_URL_FULL=https://github.com/pypa/setuptools/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:ff0c74d1b905a224d647f99c6135eacbec2620219992186b81aa20012bc7f882
+      SOURCE_URL=https://files.pythonhosted.org/packages/84/48/5c99d8770fd0a9eb0f82654c3294aad6d0ba9f8600638c2e2ad74f2c5d52/
+      SOURCE_VFY=sha256:fb3a1ee622509550dbf1d419f241296169d7f09cb1eb5b1736f2f10965932b96
         WEB_SITE=http://packages.python.org/distribute/
          ENTERED=20071221
          UPDATED=20220119

--- a/python/python-setuptools/PRE_BUILD
+++ b/python/python-setuptools/PRE_BUILD
@@ -1,2 +1,0 @@
-default_pre_build &&
-python3 bootstrap.py


### PR DESCRIPTION
…his after enough modules have

been installed to get a desktop (KDE), I don't know. After some digging and trying the next version
53.0.0, it failed as well but with a little more information, specifically;

"Make sure you're either building from a fully intact git repository or PyPI tarballs.
Most other sources (such as GitHub's tarballs, a git checkout without the .git folder)
don't contain the necessary metadata and will not work."

So changed the source url to https://pypi.org/project/setuptools/52.0.0/#files and it worked.

I can only assume there is a particular python module I install that virtually no one else does.

Anyway, for me the issue is solved..... for now. :)