### PR TITLE
pciutils: Version bump to 3.8.0, change location of pci.ids file

### DIFF
--- a/utils/pciutils/DETAILS
+++ b/utils/pciutils/DETAILS
@@ -1,13 +1,13 @@
           MODULE=pciutils
-         VERSION=3.7.0
+         VERSION=3.8.0
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=pci.ids.bz2
       SOURCE_URL=$KERNEL_URL/pub/software/utils/$MODULE
-      SOURCE2_URL=http://pciids.sourceforge.net
-      SOURCE_VFY=sha256:2432e7a2e12000502d36cf769ab6e5a0cf4931e5050ccaf8b02984b2d3cb0948
+      SOURCE2_URL=http://pci-ids.ucw.cz/v2.2/
+      SOURCE_VFY=sha256:f79fadc7fc88750877e4474c22e4b2d627e3d97d9445d1a04a88ca1d701f070f
         WEB_SITE=http://mfj.ucw.cz/pciutils.html
          ENTERED=20020125
-         UPDATED=20200606
+         UPDATED=20221002
            PSAFE=no
            SHORT="The setpci and lspci utils"
 


### PR DESCRIPTION
pci.ids is no longer being maintained on the sourceforge page, so here's the current location.