### PR TITLE
Libmnl: make doxygen optional

### DIFF
--- a/net/libmnl/BUILD
+++ b/net/libmnl/BUILD
@@ -1,3 +1,0 @@
-OPTS+=" --without-doxygen"
-default_build
-

--- a/net/libmnl/DEPENDS
+++ b/net/libmnl/DEPENDS
@@ -1,0 +1,5 @@
+optional_depends doxygen \
+    "--with-doxygen" \
+    "--without-doxygen" \
+    "for Doxygen documentation support" \
+    "n"


### PR DESCRIPTION
Some people might actually want the doxygen-generated documentation.

This incorporates #3140 