### PR TITLE
libunistring: version bumped to 1.1

### DIFF
--- a/libs/libunistring/BUILD
+++ b/libs/libunistring/BUILD
@@ -1,4 +1,0 @@
-# https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=cca32830b5
-sed -i '/pragma weak pthread_create/d' tests/glthread/thread.h &&
-
-default_build


### PR DESCRIPTION
Remove the sedit in BUILD since it wants an occurrence that doesn't exist anymore.