### PR TITLE
glib-2: bump to 2.73.3 and moving pcre2 to core to satisfy glib-2 dependency

### DIFF
--- a/libs/glib-2/DEPENDS
+++ b/libs/glib-2/DEPENDS
@@ -4,6 +4,7 @@ depends libffi
 depends gettext
 depends elfutils
 depends meson
+depends pcre2
 
 optional_depends gtk-doc \
                  "-D gtk_doc=true" \

--- a/libs/pcre2/BUILD
+++ b/libs/pcre2/BUILD
@@ -1,0 +1,16 @@
+bad_flags ALL &&
+
+OPTS+=" --enable-jit \
+        --enable-pcre2-16 \
+        --enable-pcre2-32 \
+        --enable-pcre2grep-libz \
+        --enable-pcre2grep-libbz2 \
+        --enable-pcre2test-libreadline \
+        --disable-static"
+
+default_config &&
+
+sedit 's:ln -s:ln -sf:' Makefile &&
+
+# normal install of pcre
+default_make

--- a/libs/pcre2/DEPENDS
+++ b/libs/pcre2/DEPENDS
@@ -1,0 +1,3 @@
+depends readline
+depends bzip2
+depends zlib

--- a/libs/pcre2/DETAILS
+++ b/libs/pcre2/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=pcre2
+         VERSION=10.40
+          SOURCE=$MODULE-$VERSION.tar.bz2
+   SOURCE_URL[0]=https://github.com/PhilipHazel/$MODULE/releases/download/$MODULE-$VERSION/
+      SOURCE_VFY=sha256:14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68
+        WEB_SITE=http://www.pcre.org
+         ENTERED=20180206
+         UPDATED=20220508
+           SHORT="Perl compatible regular expression library 2nd version"
+
+cat << EOF
+The PCRE library is a set of functions that implement regular expression
+pattern matching using the same syntax and semantics as Perl 5, with just a few
+differences. PCRE was originally written for the Exim MTA, but is now used by
+many projects including Python, Apache, Postfix, KDE, Analog, PHP and Ferite.
+EOF


### PR DESCRIPTION
This incorporates #3128 