### PR TITLE
python: Change the default to rebuild python modules from yes to no. …

### DIFF
--- a/python/python/POST_INSTALL
+++ b/python/python/POST_INSTALL
@@ -4,7 +4,7 @@ message "handles modules. They may need to be recompiled in order to work, espec
 message "on a major version change like 3.0 to 3.1 Minor version numbers,"
 message "like 3.3.0, to 3.3.1 are usually safe without recompiling.${DEFAULT_COLOR}"
 
-if query "Do you want lunar to attempt to upgrade your Python modules?" ${ASK_FOR_REBUILDS:-y}; then
+if query "Do you want lunar to attempt to upgrade your Python modules?" ${ASK_FOR_REBUILDS:-n}; then
   PYTHONMODS="$( lvu from /usr/lib/python3*/site-packages | cut -d: -f1 | uniq | grep -v '^[pP]ython')"
   for PYTHONMOD in $(sort_by_dependency $PYTHONMODS); do
     lin -c $PYTHONMOD || true


### PR DESCRIPTION
…In the effort to eliminate conflicts

of python modules, for now a lunar fix python is needed for those conflicting modules. I think defaulting to no would be more sensible. Right now with a yes default it will kick off any module depending on python regardless of this conflict resolution effort and casue a large amount of recompiles when not really needed.