### PR TITLE
Libffi Disabling static 

### DIFF
--- a/libs/libffi/BUILD
+++ b/libs/libffi/BUILD
@@ -1,5 +1,4 @@
-OPTS+=" --disable-static
-        --disable-multi-os-directory \
+OPTS+=" --disable-multi-os-directory \
         --disable-exec-static-tramp \
         --enable-pax_emutramp"
 

--- a/python/python/POST_INSTALL
+++ b/python/python/POST_INSTALL
@@ -4,7 +4,7 @@ message "handles modules. They may need to be recompiled in order to work, espec
 message "on a major version change like 3.0 to 3.1 Minor version numbers,"
 message "like 3.3.0, to 3.3.1 are usually safe without recompiling.${DEFAULT_COLOR}"
 
-if query "Do you want lunar to attempt to upgrade your Python modules?" ${ASK_FOR_REBUILDS:-y}; then
+if query "Do you want lunar to attempt to upgrade your Python modules?" ${ASK_FOR_REBUILDS:-n}; then
   PYTHONMODS="$( lvu from /usr/lib/python3*/site-packages | cut -d: -f1 | uniq | grep -v '^[pP]ython')"
   for PYTHONMOD in $(sort_by_dependency $PYTHONMODS); do
     lin -c $PYTHONMOD || true


### PR DESCRIPTION
disabling static in BUILD. While testing chromium bump the make failed on libffi_pic.a which is provided by the tarball. In chromiums linux/libffi/BUILD.gn it says system libffic must be compile statically. Doing this the build progressed beyond the error.