### PR TITLE
python-setuptools: Bump to 67.4.0.

### DIFF
--- a/python/python-setuptools/DETAILS
+++ b/python/python-setuptools/DETAILS
@@ -1,15 +1,12 @@
           MODULE=python-setuptools
-         # DO NOT UPDATE THE VERSION
-         # Due to deprecations later versions tend to be incompatible with the
-         # majority of python modules. Consult Ratler if you are unsure.
-         VERSION=52.0.0
+         VERSION=67.4.0
           SOURCE=setuptools-$VERSION.tar.gz
+      SOURCE_URL=https://pypi.org/packages/source/s/setuptools/
+      SOURCE_VFY=sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/setuptools-$VERSION
-      SOURCE_URL=https://files.pythonhosted.org/packages/84/48/5c99d8770fd0a9eb0f82654c3294aad6d0ba9f8600638c2e2ad74f2c5d52/
-      SOURCE_VFY=sha256:fb3a1ee622509550dbf1d419f241296169d7f09cb1eb5b1736f2f10965932b96
         WEB_SITE=http://packages.python.org/distribute/
          ENTERED=20071221
-         UPDATED=20220119
+         UPDATED=20230228
             TYPE=python3
         REPLACES=setuptools-3
            SHORT="A simplified packaging system for Python 3.x"


### PR DESCRIPTION
The modules in core dependent on setuptools went ok. A wholly incomplete test of other python modules went ok. Cannot guarantee no issues.