### PR TITLE
glib-2: Bump to 2.76.0 and removing the invalid switch.

### DIFF
--- a/libs/glib-2/BUILD
+++ b/libs/glib-2/BUILD
@@ -1,5 +1,4 @@
 OPTS+=" -D installed_tests=false \
-        -D fam=false \
         -D selinux=disabled"
 
 # Do not install gdbus-codegen, it's part of gdbus-codegen module

--- a/libs/glib-2/DEPENDS
+++ b/libs/glib-2/DEPENDS
@@ -1,6 +1,7 @@
 depends automake
 depends zlib
 depends libffi
+depends pcre2
 depends gettext
 depends elfutils
 depends meson

--- a/libs/glib-2/DETAILS
+++ b/libs/glib-2/DETAILS
@@ -1,12 +1,12 @@
           MODULE=glib-2
-         VERSION=2.72.2
+         VERSION=2.76.0
           SOURCE=${MODULE%-*}-$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE%-*}-$VERSION
       SOURCE_URL=$GNOME_URL/sources/glib/${VERSION%.*}
-      SOURCE_VFY=sha256:78d599a133dba7fe2036dfa8db8fb6131ab9642783fc9578b07a20995252d2de
+      SOURCE_VFY=sha256:525bb703b807142e1aee5ccf222c344e8064b21c0c45677ef594e587874c6797
         WEB_SITE=http://library.gnome.org/devel/glib
          ENTERED=20020313
-         UPDATED=20220606
+         UPDATED=20230315
            SHORT="A library of useful C routines for trees, hashes, and lists"
 
 cat << EOF


### PR DESCRIPTION
Our current version of glib-2 to old for the current gobject-introspection which will silently pull in the version of glib-2 it needs. The problem with that it stomps on the system glib-2. So a install or recompile of gobject-introspection will fail leaving you with a broken glib-2 and the reason for https://github.com/lunar-linux/moonbase-other/issues/2262.