### PR TITLE
curl: Bump to 8.0.1. Closed 6 CVEs and they claim there are no API or…

### DIFF
--- a/ftp/curl/DETAILS
+++ b/ftp/curl/DETAILS
@@ -1,11 +1,11 @@
           MODULE=curl
-         VERSION=7.88.1
+         VERSION=8.0.1
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://curl.haxx.se/download/
-      SOURCE_VFY=sha256:8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907
+      SOURCE_VFY=sha256:9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf
         WEB_SITE=https://curl.haxx.se/
          ENTERED=20010922
-         UPDATED=20230221
+         UPDATED=20230320
            SHORT="Tool for transferring files using URL syntax"
 
 cat << EOF


### PR DESCRIPTION
… ABI breakage.

See:https://daniel.haxx.se/blog/2023/03/20/curl-8-0-0-is-here/