### PR TITLE
dmidecode: Bump to 3.5.

### DIFF
--- a/utils/dmidecode/DETAILS
+++ b/utils/dmidecode/DETAILS
@@ -1,12 +1,12 @@
           MODULE=dmidecode
-         VERSION=3.4
+         VERSION=3.5
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://download.savannah.nongnu.org/releases/$MODULE/
-      SOURCE_VFY=sha256:43cba851d8467c9979ccdbeab192eb6638c7d3a697eba5ddb779da8837542212
+      SOURCE_URL=https://download.savannah.gnu.org/releases/dmidecode/
+      SOURCE_VFY=sha256:79d76735ee8e25196e2a722964cf9683f5a09581503537884b256b01389cc073
         WEB_SITE=https://www.nongnu.org/dmidecode/
       MAINTAINER=ratler@lunar-linux.org
          ENTERED=20040629
-         UPDATED=20220916
+         UPDATED=20230321
            SHORT="Tool for dumping a computer's DMI (SMBIOS) in a human-readable format"
 
 cat << EOF


### PR DESCRIPTION
If it fails to grab the tarball blame savannah. Couldn't fine a reliable server.