### PR TITLE
pcre2: moving from other to core

### DIFF
--- a/libs/pcre2/BUILD
+++ b/libs/pcre2/BUILD
@@ -1,0 +1,16 @@
+bad_flags ALL &&
+
+OPTS+=" --enable-jit \
+        --enable-pcre2-16 \
+        --enable-pcre2-32 \
+        --enable-pcre2grep-libz \
+        --enable-pcre2grep-libbz2 \
+        --enable-pcre2test-libreadline \
+        --disable-static"
+
+default_config &&
+
+sedit 's:ln -s:ln -sf:' Makefile &&
+
+# normal install of pcre
+default_make

--- a/libs/pcre2/DEPENDS
+++ b/libs/pcre2/DEPENDS
@@ -1,0 +1,3 @@
+depends readline
+depends bzip2
+depends zlib

--- a/libs/pcre2/DETAILS
+++ b/libs/pcre2/DETAILS
@@ -1,0 +1,16 @@
+          MODULE=pcre2
+         VERSION=10.41
+          SOURCE=$MODULE-$VERSION.tar.bz2
+      SOURCE_URL=https://github.com/PhilipHazel/$MODULE/releases/download/$MODULE-$VERSION/
+      SOURCE_VFY=sha256:0f78cebd3e28e346475fb92e95fe9999945b4cbaad5f3b42aca47b887fb53308
+        WEB_SITE=http://www.pcre.org
+         ENTERED=20180206
+         UPDATED=20221222
+           SHORT="Perl compatible regular expression library 2nd version"
+
+cat << EOF
+The PCRE library is a set of functions that implement regular expression
+pattern matching using the same syntax and semantics as Perl 5, with just a few
+differences. PCRE was originally written for the Exim MTA, but is now used by
+many projects including Python, Apache, Postfix, KDE, Analog, PHP and Ferite.
+EOF


### PR DESCRIPTION
The latest glib2 insists that pcre2 be present, and insists so hard that it tries to download it if it's not already installed.