### PR TITLE
xz: version bumped to 5.2.11

### DIFF
--- a/archive/xz/DETAILS
+++ b/archive/xz/DETAILS
@@ -1,11 +1,11 @@
          MODULE=xz
-        VERSION=5.2.10
+        VERSION=5.2.11
          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=http://tukaani.org/$MODULE
-      SOURCE_VFY=sha256:eb7a3b2623c9d0135da70ca12808a214be9c019132baaa61c9e1d198d1d9ded3
-        WEB_SITE=http://tukaani.org/xz
+      SOURCE_URL=https://tukaani.org/$MODULE
+      SOURCE_VFY=sha256:0089d47b966bd9ab48f1d01baf7ce146a3b591716c7477866b807010de3d96ab
+        WEB_SITE=https://tukaani.org/xz
          ENTERED=20090224
-         UPDATED=20221226
+         UPDATED=20230323
            SHORT="Utils for XZ archive format"
 
 cat << EOF


### PR DESCRIPTION
xz 5.4.2 still gives a warning:
`xz: Reduced the number of threads from 1 to one. The automatic memory usage limi
t of 242 MiB is still being exceeded. 1250 MiB of memory is required. Continuing
 anyway.`
So opt for the old 5.2 branch instead