### PR TITLE
ca-certificates: Version bumped to 20230311

### DIFF
--- a/crypto/ca-certificates/DETAILS
+++ b/crypto/ca-certificates/DETAILS
@@ -1,11 +1,11 @@
           MODULE=ca-certificates
-         VERSION=20211016
+         VERSION=20230311
           SOURCE=${MODULE}_$VERSION.tar.xz
       SOURCE_URL=https://cdn-fastly.deb.debian.org/debian/pool/main/c/$MODULE
-      SOURCE_VFY=sha256:2ae9b6dc5f40c25d6d7fe55e07b54f12a8967d1955d3b7b2f42ee46266eeef88
+      SOURCE_VFY=sha256:83de934afa186e279d1ed08ea0d73f5cf43a6fbfb5f00874b6db3711c64576f3
         WEB_SITE=https://packages.qa.debian.org/c/ca-certificates.html
          ENTERED=20100405
-         UPDATED=20220607
+         UPDATED=20230504
            SHORT="Common CA certificates"
 
 cat << EOF

--- a/crypto/ca-certificates/patch.d/python-cryptography-elimination.patch
+++ b/crypto/ca-certificates/patch.d/python-cryptography-elimination.patch
@@ -1,26 +1,25 @@
-diff -r -C 2 work/mozilla/certdata2pem.py work.new/mozilla/certdata2pem.py
-*** work/mozilla/certdata2pem.py	2021-10-17 01:09:43.000000000 +0900
---- work.new/mozilla/certdata2pem.py	2022-10-29 16:36:57.272711665 +0900
+*** ca-certificates/mozilla/certdata2pem.py     2023-01-14 22:58:27.000000000 +0900
+--- ca-certificates.new/mozilla/certdata2pem.py 2023-05-04 19:47:55.809483254 +0900
 ***************
 *** 29,35 ****
   import io
-  
+
 - from cryptography import x509
-- 
-- 
+-
+-
   objects = []
-  
+
 --- 29,32 ----
 ***************
 *** 123,132 ****
               continue
-  
--         cert = x509.load_der_x509_certificate(obj['CKA_VALUE'])
--         if cert.not_valid_after < datetime.datetime.now():
+
+-         cert = x509.load_der_x509_certificate(bytes(obj['CKA_VALUE']))
+-         if cert.not_valid_after < datetime.datetime.utcnow():
 -             print('!'*74)
 -             print('Trusted but expired certificate found: %s' % obj['CKA_LABEL'])
 -             print('!'*74)
-- 
+-
           bname = obj['CKA_LABEL'][1:-1].replace('/', '_')\
                                         .replace(' ', '_')\
 --- 120,123 ----


### PR DESCRIPTION
This one's a bit urgent because the previous one's been removed from the download location so ca-certificates updates will definitely fail