### PR TITLE
pciutils: Add hard dependency on wget

### DIFF
--- a/utils/pciutils/DEPENDS
+++ b/utils/pciutils/DEPENDS
@@ -1,2 +1,3 @@
 depends kmod
 depends zlib
+depends wget

--- a/utils/pciutils/DETAILS
+++ b/utils/pciutils/DETAILS
@@ -7,7 +7,7 @@
       SOURCE_VFY=sha256:238a2e27166730e53a17fe07bfad229e07fa39b618117e5944b6d7eda9fbb0e9
         WEB_SITE=http://mfj.ucw.cz/pciutils.html
          ENTERED=20020125
-         UPDATED=20230501
+         UPDATED=20230802
            PSAFE=no
            SHORT="The setpci and lspci utils"
 


### PR DESCRIPTION
Even though nothing in core is supposed to be downloading anything from the Internet as part of its build (because if you're building an ISO, by definition you'll have an incomplete system), pciutils thinks that it's special and insists on downloading a new pci.ids file just in case it's changed in the last half hour or so.

(The pci.ids file chagnes on average once a month. It's not that special.)

So until there's a better fix, just add another layer of stupid, ugly hackwork on top of the existing pile of problems.