### PR TITLE
curl: version bumped to 8.3.0 (security)

### DIFF
--- a/ftp/curl/DEPENDS
+++ b/ftp/curl/DEPENDS
@@ -7,17 +7,12 @@ optional_depends libidn2 "--with-libidn2" \
 optional_depends %OSSL \
                  "--with-ssl" \
                  "--without-ssl" \
-                 "for SSL encrypted transport ${PROBLEM_COLOR}(Choose only openssl OR gnutls OR nss)" y
+                 "for SSL encrypted transport ${PROBLEM_COLOR}(Choose only openssl OR gnutls)" y
 
 optional_depends gnutls \
                  "--with-gnutls" \
                  "--without-gnutls" \
-                 "for nss encrypted transport ${PROBLEM_COLOR}(Choose only openssl OR gnutls OR nss)" n
-
-optional_depends nss \
-                 "--with-nss" \
-                 "--without-nss" \
-                 "for nss encrypted transport ${PROBLEM_COLOR}(Choose only openssl OR gnutls OR nss)" n
+                 "for gnutls encrypted transport ${PROBLEM_COLOR}(Choose only openssl OR gnutls)" n
 
 optional_depends libssh2 \
                  "--with-libssh2" \

--- a/ftp/curl/DETAILS
+++ b/ftp/curl/DETAILS
@@ -1,11 +1,11 @@
           MODULE=curl
-         VERSION=8.2.1
+         VERSION=8.3.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://curl.haxx.se/download/
-      SOURCE_VFY=sha256:dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
+      SOURCE_VFY=sha256:376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63
         WEB_SITE=https://curl.haxx.se/
          ENTERED=20010922
-         UPDATED=20230728
+         UPDATED=20230915
            SHORT="Tool for transferring files using URL syntax"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2023-38039 : HTTP headers eat all memory (https://curl.se/docs/CVE-2023-38039.html)
Also nss support has been removed.