### PR TITLE
curl: version bumped to 8.4.0, security fix

### DIFF
--- a/ftp/curl/DETAILS
+++ b/ftp/curl/DETAILS
@@ -1,11 +1,11 @@
           MODULE=curl
-         VERSION=8.3.0
+         VERSION=8.4.0
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://curl.haxx.se/download/
-      SOURCE_VFY=sha256:376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63
+      SOURCE_VFY=sha256:16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d
         WEB_SITE=https://curl.haxx.se/
          ENTERED=20010922
-         UPDATED=20230915
+         UPDATED=20231011
            SHORT="Tool for transferring files using URL syntax"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2023-38545 (SOCKS5 heap buffer overflow) and CVE-2023-38546 (cookie injection flaw).