### PR TITLE
libusb-compat: Fixing up DETAILS and BUILD. No version bump here. It

### DIFF
--- a/libs/libusb-compat/BUILD
+++ b/libs/libusb-compat/BUILD
@@ -1,4 +1,2 @@
-./autogen.sh &&
-
 OPTS+=" --disable-static" &&
 default_build

--- a/libs/libusb-compat/DETAILS
+++ b/libs/libusb-compat/DETAILS
@@ -2,7 +2,7 @@
          VERSION=0.1.8
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=https://github.com/libusb/libusb-compat-0.1/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:698c76484f3dec1e0175067cbd1556c3021e94e7f2313ae3ea6a66d900e00827
+      SOURCE_VFY=sha256:b692dcf674c070c8c0bee3c8230ce4ee5903f926d77dc8b968a4dd1b70f9b05c
         WEB_SITE=http://www.libusb.org/wiki/LibusbCompat0.1
          ENTERED=20090812
          UPDATED=20230315

--- a/libs/libusb-compat/DETAILS
+++ b/libs/libusb-compat/DETAILS
@@ -1,8 +1,8 @@
           MODULE=libusb-compat
          VERSION=0.1.8
-          SOURCE=$MODULE-$VERSION.tar.bz2
+          SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/libusb/libusb-compat-0.1/releases/download/v$VERSION/
-      SOURCE_VFY=sha256:b692dcf674c070c8c0bee3c8230ce4ee5903f926d77dc8b968a4dd1b70f9b05c
+      SOURCE_VFY=sha256:d199c173fd3cd9d27c7f4bb6608befc7eb761984e6664da7d9d4386ff66fe6fc
         WEB_SITE=http://www.libusb.org/wiki/LibusbCompat0.1
          ENTERED=20090812
          UPDATED=20230315


### PR DESCRIPTION
appears all they did was remove the need for autogen.sh.