### PR TITLE
popt: fix build on aarch64 systems

### DIFF
--- a/libs/popt/BUILD
+++ b/libs/popt/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-static"
+
+default_build


### PR DESCRIPTION
The error I was getting was:

[...]
libtool: install: /bin/install -c .libs/libpopt.lai /usr/lib/libpopt.la                                                       
libtool: install: /bin/install -c .libs/libpopt.a /usr/lib/libpopt.a                                                          
libtool: install: chmod 644 /usr/lib/libpopt.a                                                                                
libtool: install: ranlib /usr/lib/libpopt.a                                                                                   
../libtool: line 1720: 3593883 Segmentation fault      (core dumped) ranlib /usr/lib/libpopt.a

I believe this situation only occurs on the aarch64 architecture. I've read somewhere that it might have to do with running in a chroot, but I can't test on a bare metal system now.