### PR TITLE
libunistring: fix build failure on aarch64

### DIFF
--- a/libs/libunistring/BUILD
+++ b/libs/libunistring/BUILD
@@ -1,0 +1,3 @@
+OPTS+=" --disable-static"
+
+default_build


### PR DESCRIPTION
Same problem as in https://github.com/lunar-linux/moonbase-core/pull/3407

I've tried recompiling all that depends on this, everything seems fine without libunistring.a