### PR TITLE
libffi: another static-disabling fix for aarch64 build

### DIFF
--- a/libs/libffi/BUILD
+++ b/libs/libffi/BUILD
@@ -1,5 +1,6 @@
 OPTS+=" --disable-multi-os-directory \
         --disable-exec-static-tramp \
+        --disable-static \
         --enable-pax_emutramp"
 
 default_build


### PR DESCRIPTION
This is for the same problem as popt (https://github.com/lunar-linux/moonbase-core/pull/3407)

The error I was getting was:

[...]
make[3]: Entering directory '/usr/src/libffi-3.4.4/aarch64-unknown-linux-gnu'
 /bin/mkdir -p '/usr/lib/pkgconfig'
 /bin/mkdir -p '/usr/lib'
 /bin/sh ./libtool   --mode=install /bin/install -c   libffi.la '/usr/lib'
 /bin/install -c -m 644 libffi.pc '/usr/lib/pkgconfig'
libtool: install: /bin/install -c .libs/libffi.so.8.1.2 /usr/lib/libffi.so.8.1.2
libtool: install: (cd /usr/lib && { ln -s -f libffi.so.8.1.2 libffi.so.8 || { rm -f libffi.so.8 && ln -s libffi.so.8.1.2 libffi.so.8; }; })
libtool: install: (cd /usr/lib && { ln -s -f libffi.so.8.1.2 libffi.so || { rm -f libffi.so && ln -s libffi.so.8.1.2 libffi.so; }; })
libtool: install: /bin/install -c .libs/libffi.lai /usr/lib/libffi.la
libtool: install: /bin/install -c .libs/libffi.a /usr/lib/libffi.a
libtool: install: chmod 644 /usr/lib/libffi.a
libtool: install: ranlib /usr/lib/libffi.a
./libtool: line 1901: 4127566 Segmentation fault      (core dumped) ranlib /usr/lib/libffi.a
make[3]: *** [Makefile:693: install-toolexeclibLTLIBRARIES] Error 139
make[3]: Leaving directory '/usr/src/libffi-3.4.4/aarch64-unknown-linux-gnu'
make[2]: *** [Makefile:1709: install-am] Error 2
make[2]: Leaving directory '/usr/src/libffi-3.4.4/aarch64-unknown-linux-gnu'
make[1]: *** [Makefile:1397: install-recursive] Error 1
make[1]: Leaving directory '/usr/src/libffi-3.4.4/aarch64-unknown-linux-gnu'
make: *** [Makefile:3159: install] Error 2
