### PR TITLE
libidn2: fix build on aarch64 (disable static)

### DIFF
--- a/libs/libidn2/BUILD
+++ b/libs/libidn2/BUILD
@@ -1,3 +1,4 @@
-OPTS+=" --disable-gtk-doc"
+OPTS+=" --disable-gtk-doc \
+        --disable-static"
 
 default_build


### PR DESCRIPTION
Same problem as popt (https://github.com/lunar-linux/moonbase-core/pull/3407)...

The error I got was:
[...]
make[4]: Entering directory '/usr/src/libidn2-2.3.4/lib'                                                                      
 /bin/mkdir -p '/usr/lib'                                                                                                     
 /bin/mkdir -p '/usr/include'                                                                                                 
 /bin/sh ../libtool   --mode=install /bin/install -c   libidn2.la '/usr/lib'                                                  
 /bin/install -c -m 644 idn2.h '/usr/include'                                                                                 
libtool: install: /bin/install -c .libs/libidn2.so.0.3.8 /usr/lib/libidn2.so.0.3.8                                            
libtool: install: (cd /usr/lib && { ln -s -f libidn2.so.0.3.8 libidn2.so.0 || { rm -f libidn2.so.0 && ln -s libidn2.so.0.3.8 l
ibidn2.so.0; }; })                                                                                                            
libtool: install: (cd /usr/lib && { ln -s -f libidn2.so.0.3.8 libidn2.so || { rm -f libidn2.so && ln -s libidn2.so.0.3.8 libid
n2.so; }; })                                                                                                                  
libtool: install: /bin/install -c .libs/libidn2.lai /usr/lib/libidn2.la                                                       
libtool: install: /bin/install -c .libs/libidn2.a /usr/lib/libidn2.a                                                          
libtool: install: chmod 644 /usr/lib/libidn2.a                                                                                
libtool: install: ranlib /usr/lib/libidn2.a                                                                                   
../libtool: line 1890: 4147643 Segmentation fault      (core dumped) ranlib /usr/lib/libidn2.a                                
make[4]: *** [Makefile:1571: install-libLTLIBRARIES] Error 139                                                                
make[4]: Leaving directory '/usr/src/libidn2-2.3.4/lib'                                                                       
make[3]: *** [Makefile:1806: install-am] Error 2                                                                              
make[3]: Leaving directory '/usr/src/libidn2-2.3.4/lib'                                                                       
make[2]: *** [Makefile:1799: install] Error 2                                                                                 
make[2]: Leaving directory '/usr/src/libidn2-2.3.4/lib'                                                                       
make[1]: *** [Makefile:1652: install-recursive] Error 1                                                                       
make[1]: Leaving directory '/usr/src/libidn2-2.3.4'                                                                           
make: *** [Makefile:1960: install] Error 2