### PR TITLE
dmraid: fix build on aarch64

### DIFF
--- a/filesys/dmraid/BUILD
+++ b/filesys/dmraid/BUILD
@@ -1,3 +1,4 @@
 export LDFLAGS+=" -ldevmapper"
 cd $VERSION/$MODULE &&
+autoreconf -fi &&
 default_build


### PR DESCRIPTION
This time the error I was getting was:

[...]
\+ ./configure --build=aarch64-linux-gnu --prefix=/usr --sysconfdir=/etc --localstatedir=/var --infodir=/usr/share/info --mandi
r=/usr/share/man                                                                                                              
checking build system type... Invalid configuration 'aarch64-linux-gnu': machine 'aarch64' not recognized                     
configure: error: /bin/sh autoconf/config.sub aarch64-linux-gnu failed