### PR TITLE
wipe: fix build on aarch64

### DIFF
--- a/utils/wipe/BUILD
+++ b/utils/wipe/BUILD
@@ -1,0 +1,3 @@
+autoreconf -fi &&
+
+default_build


### PR DESCRIPTION
The error I was getting was:

configure: error: can not guess host type; you must specify one