### PR TITLE
curl: version bumped to 8.6.0

### DIFF
--- a/ftp/curl/DETAILS
+++ b/ftp/curl/DETAILS
@@ -1,11 +1,11 @@
           MODULE=curl
-         VERSION=8.5.0
+         VERSION=8.6.0
           SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://curl.haxx.se/download/
-      SOURCE_VFY=sha256:42ab8db9e20d8290a3b633e7fbb3cec15db34df65fd1015ef8ac1e4723750eeb
-        WEB_SITE=https://curl.haxx.se/
+      SOURCE_URL=https://curl.se/download/
+      SOURCE_VFY=sha256:3ccd55d91af9516539df80625f818c734dc6f2ecf9bada33c76765e99121db15
+        WEB_SITE=https://curl.se/
          ENTERED=20010922
-         UPDATED=20231209
+         UPDATED=20240203
            SHORT="Tool for transferring files using URL syntax"
 
 cat << EOF


### PR DESCRIPTION
The new URL is taken from a redirect.