### PR TITLE
openssh: version bumped to 9.7p1 + new DSA option

### DIFF
--- a/crypto/openssh/CONFIGURE
+++ b/crypto/openssh/CONFIGURE
@@ -1,0 +1,2 @@
+mquery DISABLE_DSA "Disable DSA key support?" n \
+        "--disable-dsa-keys" "--enable-dsa-keys"

--- a/crypto/openssh/DETAILS
+++ b/crypto/openssh/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openssh
-         VERSION=9.6p1
+         VERSION=9.7p1
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://ftp3.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable
    SOURCE_URL[1]=ftp://ftp5.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable
    SOURCE_URL[2]=ftp://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable
-      SOURCE_VFY=sha256:910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c
+      SOURCE_VFY=sha256:490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd
         WEB_SITE=http://www.openssh.com/
          ENTERED=20010922
-         UPDATED=20231230
+         UPDATED=20240313
            SHORT="Client and server for encrypted remote logins and file transfers"
 
 cat << EOF


### PR DESCRIPTION
In the configure script it defaults to no for now, so also default to no in the mquery.