### PR TITLE
xz: Roll back bumps to 5.6.0, 5.6.1.

### DIFF
--- a/archive/xz/DETAILS
+++ b/archive/xz/DETAILS
@@ -1,11 +1,11 @@
          MODULE=xz
-        VERSION=5.6.1
+        VERSION=5.4.6
          SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://github.com/tukaani-project/xz/releases/download/v${VERSION}/
-      SOURCE_VFY=sha256:2398f4a8e53345325f44bdd9f0cc7401bd9025d736c6d43b372f4dea77bf75b8
+      SOURCE_VFY=sha256:aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c
         WEB_SITE=https://xz.tukaani.org/xz-utils/
          ENTERED=20090224
-         UPDATED=20240310
+         UPDATED=20240330
            SHORT="Utils for XZ archive format"
 
 cat << EOF


### PR DESCRIPTION
See:
https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/

Someone managed to sneak a backdoor into xz 5.6 and it hasn't been fixed in the xz mainline yet, so rolling back to before it was introduced.