### PR TITLE
Python: Version bumped to 3.12.3

### DIFF
--- a/python/python/BUILD
+++ b/python/python/BUILD
@@ -2,7 +2,6 @@ OPTS+=" --enable-shared \
         --enable-ipv6 \
         --with-system-ffi \
         --with-system-expat \
-        --with-system-libmpdec \
         --with-computed-gotos \
         --without-ensurepip"
 

--- a/python/python/DEPENDS
+++ b/python/python/DEPENDS
@@ -8,3 +8,4 @@ depends zlib
 optional_depends db     "" "" "for db support"
 optional_depends gdbm   "" "" "for gdbm support"
 optional_depends sqlite "" "" "for sqlite support"
+optional_depends mpdecimal "--with-system-mpdec" "" "use system mpdecimal instead of mpdecimal bundled with python"

--- a/python/python/DETAILS
+++ b/python/python/DETAILS
@@ -1,12 +1,12 @@
           MODULE=python
-         VERSION=3.11.2
+         VERSION=3.12.3
           SOURCE=Python-$VERSION.tgz
       SOURCE_URL=https://www.python.org/ftp/python/$VERSION/
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/Python-$VERSION
-      SOURCE_VFY=sha256:2411c74bda5bbcfcddaf4531f66d1adc73f247f529aee981b029513aefdbf849
+      SOURCE_VFY=sha256:a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0
         WEB_SITE=http://www.python.org
          ENTERED=20121013
-         UPDATED=20230226
+         UPDATED=20240511
         REPLACES=Python-3
            SHORT="Interpreted, interactive, object-oriented programming language"
 

--- a/python/python/PRE_BUILD
+++ b/python/python/PRE_BUILD
@@ -9,4 +9,3 @@ sed -i -e "s|^#.* /usr/local/bin/python|#!/usr/bin/python|" Lib/cgi.py &&
 # Ensure that we link against system libraries
 rm -rf Modules/{expat,zlib} &&
 rm -rf Modules/_ctypes/{darwin,libffi}*
-rm -r Modules/_decimal/libmpdec


### PR DESCRIPTION
Also hopefully made it so mpdecimal doesn't need to be moved into moonbase-core just to support Python.