### PR TITLE
grep: The warning in /usr/bin/fgrep was causing atlas to fail its build.

### DIFF
--- a/utils/grep/BUILD
+++ b/utils/grep/BUILD
@@ -23,4 +23,4 @@ default_build &&
 # I've encountered. The issue is with this lin in fgrep;
 # echo "$cmd: warning: $cmd is obsolescent; using grep -F" >&2
 # So we'll just comment that out.
-sed -i 's/^echo/\\#echo/' /usr/bin/fgrep
+sed -i 's/^echo/#echo/' /usr/bin/fgrep

--- a/utils/grep/BUILD
+++ b/utils/grep/BUILD
@@ -17,4 +17,10 @@ else
 fi &&
 
 sedit "s/SYMLINK=\"ln -s\"/SYMLINK=\"ln -sf\"/" configure &&
-default_build
+default_build &&
+
+# NOTE: current fgrep causes atlas build to fail. So far its the only module
+# I've encountered. The issue is with this lin in fgrep;
+# echo "$cmd: warning: $cmd is obsolescent; using grep -F" >&2
+# So we'll just comment that out.
+sed -i 's/^echo/\\#echo/' /usr/bin/fgrep

--- a/utils/grep/DETAILS
+++ b/utils/grep/DETAILS
@@ -6,7 +6,7 @@
       SOURCE_VFY=sha256:1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab
         WEB_SITE=http://www.gnu.org/software/grep/grep.html
          ENTERED=20010922
-         UPDATED=20240204
+         UPDATED=20240517
            SHORT="grep finds lines that match specified patterns"
 
 cat << EOF


### PR DESCRIPTION
Commenting out that line with the warning fixes the atlas build. There may be other modules effected by the warning but atlas is the only one I know of at this time.