### PR TITLE
readline: add pkgconfig links in proper location

### DIFF
--- a/libs/readline/BUILD
+++ b/libs/readline/BUILD
@@ -15,8 +15,8 @@ make SHLIB_LIBS=-lncurses &&
 prepare_install &&
 make install &&
 
-ln -sf /lib/pkgconfig/readline.pc /usr/lib/pkgconfig/ &&
-ln -sf /lib/pkgconfig/history.pc /usr/lib/pkgconfig/ &&
+mv /lib/pkgconfig/readline.pc /usr/lib/pkgconfig/ &&
+mv /lib/pkgconfig/history.pc /usr/lib/pkgconfig/ &&
 
 if [ ! -e /etc/inputrc ]; then
   install $SCRIPT_DIRECTORY/inputrc /etc/

--- a/libs/readline/BUILD
+++ b/libs/readline/BUILD
@@ -15,6 +15,9 @@ make SHLIB_LIBS=-lncurses &&
 prepare_install &&
 make install &&
 
+ln -sf /lib/pkgconfig/readline.pc /usr/lib/pkgconfig/ &&
+ln -sf /lib/pkgconfig/history.pc /usr/lib/pkgconfig/ &&
+
 if [ ! -e /etc/inputrc ]; then
   install $SCRIPT_DIRECTORY/inputrc /etc/
 fi


### PR DESCRIPTION
This is related to https://github.com/lunar-linux/moonbase-other/pull/3755 which I was rewriting to cmake... so rpm-tools can't find readline's pkgconfig files in /lib/pkgconfig/. No clues why it doesn't search there though. I thought putting a link at the correct place could also help with other modules having this hiccup, probably part of the usrmerge movement, who knows :P