### PR TITLE
Libxcrypt: move to core

### DIFF
--- a/crypto/libxcrypt/BUILD
+++ b/crypto/libxcrypt/BUILD
@@ -1,0 +1,12 @@
+# Its include conflicts with glibc:/usr/include/crypt.h and
+# its /usr/lib/libcrypt.so conflicts with glibc
+OPTS+=" --enable-hashes=strong,glibc \
+        --enable-obsolete-api=no \
+        --disable-failure-tokens \
+        --disable-static \
+        --disable-werror \
+        --libdir=/usr/lib/$MODULE \
+        --includedir=/usr/include/$MODULE \
+        " &&
+
+default_build

--- a/crypto/libxcrypt/BUILD
+++ b/crypto/libxcrypt/BUILD
@@ -5,8 +5,8 @@ OPTS+=" --enable-hashes=strong,glibc \
         --disable-failure-tokens \
         --disable-static \
         --disable-werror \
-        --libdir=/usr/lib/$MODULE \
-        --includedir=/usr/include/$MODULE \
+        --libdir=/usr/lib \
+        --includedir=/usr/include \
         " &&
 
 default_build

--- a/crypto/libxcrypt/DETAILS
+++ b/crypto/libxcrypt/DETAILS
@@ -1,0 +1,19 @@
+          MODULE=libxcrypt
+         VERSION=4.4.36
+          SOURCE=$MODULE-$VERSION.tar.xz
+      SOURCE_URL=https://github.com/besser82/libxcrypt/releases/download/v$VERSION
+      SOURCE_VFY=sha256:e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943
+        WEB_SITE=https://github.com/besser82/libxcrypt/
+         ENTERED=20201025
+         UPDATED=20230801
+           SHORT="Modern library for one-way hashing of passwords"
+
+cat << EOF
+libxcrypt is a modern library for one-way hashing of passwords. It supports a
+wide variety of both modern and historical hashing methods: yescrypt, gost-
+yescrypt, scrypt, bcrypt, sha512crypt, sha256crypt, md5crypt, SunMD5, sha1crypt,
+NT, bsdicrypt, bigcrypt, and descrypt. It provides the traditional Unix crypt
+and crypt_r interfaces, as well as a set of extended interfaces pioneered by
+Openwall Linux, crypt_rn, crypt_ra, crypt_gensalt, crypt_gensalt_rn, and
+crypt_gensalt_ra.
+EOF


### PR DESCRIPTION
The latest glibc doesn't include libcrypt (by default--but the devs have threatened to take it away altogether, so I'm preparing for that day here), so here's its replacement, libxcrypt.

Also some changes to libxcrypt to install into /usr/lib and /usr/include instead of /usr/lib/libxcrypt and /usr/include/libxcrypt respectively, on account of how without those things handy, an awful lot of the system will break.