### PR TITLE
btrfs-progs: version bumped to 6.9

### DIFF
--- a/filesys/btrfs-progs/DEPENDS
+++ b/filesys/btrfs-progs/DEPENDS
@@ -21,3 +21,4 @@ optional_depends libsodium \
 
 optional_depends xmlto    "" "" "for documentation (also requires asciidoc)" "n"
 optional_depends asciidoc "" "" "for documentation (also requires xmlto)" "n"
+optional_depends sphinxcontrib-jquery "" "" "for documentation (requires both xmlto and asciidoc)" "n"

--- a/filesys/btrfs-progs/DETAILS
+++ b/filesys/btrfs-progs/DETAILS
@@ -1,12 +1,12 @@
           MODULE=btrfs-progs
-         VERSION=6.6.1
+         VERSION=6.9
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
  SOURCE_URL_FULL=https://github.com/kdave/btrfs-progs/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:c09c0840da7e1194472bfa33799207d5e41f801f80c3e7ecb9fd7939af52f884
+      SOURCE_VFY=sha256:4d43d453f1757b83b94fd510fe03be5dc09810e5382f6b6290c4945a9e6c3652
         WEB_SITE=https://btrfs.wiki.kernel.org/index.php/Main_Page
          ENTERED=20090819
-         UPDATED=20231109
+         UPDATED=20240607
            SHORT="btrfs userspace tools"
 
 cat <<EOF


### PR DESCRIPTION
This version builds fine with the latest e2fsprogs (https://github.com/lunar-linux/moonbase-core/pull/3547).