### PR TITLE
e2fsprogs:add -D_FILE_OFFSET_BITS=64 to compile flags

### DIFF
--- a/filesys/e2fsprogs/BUILD
+++ b/filesys/e2fsprogs/BUILD
@@ -12,6 +12,8 @@ OPTS+=" --build=$BUILD      \
         --disable-libblkid  \
         --disable-fsck"    &&
 
+export CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
+
 default_build &&
 
 make install-libs || exit 1


### PR DESCRIPTION
In file included from /usr/include/fuse/fuse.h:26,
                 from /usr/include/fuse.h:9,
                 from fuse2fs.c:29:
/usr/include/fuse/fuse_common.h:33:2: error: #error Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
   33 | #error Please add -D_FILE_OFFSET_BITS=64 to your compile flags!
      |  ^~~~~
	CC mklost+found.c
	CC filefrag.c
	CC e2freefrag.c
make[2]: *** [Makefile:472: fuse2fs.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/usr/src/e2fsprogs-1.47.1/misc' make[1]: *** [Makefile:445: all-progs-recursive] Error 1 make[1]: Leaving directory '/usr/src/e2fsprogs-1.47.1' make: *** [Makefile:373: all] Error 2