### PR TITLE
binutils: fix installation on aarch64

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -42,7 +42,7 @@ echo "INPUT ( /usr/lib/libbfd.a -liberty -lz -ldl )" > $dstdir/usr/lib/libbfd.so
 echo "INPUT ( /usr/lib/libopcodes.a -lbfd )" > $dstdir/usr/lib/libopcodes.so
 
 # This part fails on i686, so check the arch
-if [[ "$(uname -m)" == "x86_64" ]]; then
+if [[ "$(uname -m)" == "x86_64" || "$(uname -m)" == "aarch64" ]]; then
 	mv $dstdir/usr/lib64/* $dstdir/usr/lib/ &&
 	rmdir $dstdir/usr/lib64
 fi &&


### PR DESCRIPTION
I was getting this on my Oracle server:

Removed module: binutils
cp: cannot overwrite non-directory '/usr/lib64' with directory '/usr/src/binutils-2.42/__destdir/usr/lib64'

So include the aarch64 arch for the fix as well.