### PR TITLE
linux: version bumped to 6.10.2

### DIFF
--- a/kernel/linux/DETAILS
+++ b/kernel/linux/DETAILS
@@ -1,5 +1,5 @@
           MODULE=linux
-         VERSION=6.9.8
+         VERSION=6.10.2
             BASE=$(echo $VERSION | cut -d. -f1,2)
           SOURCE=$MODULE-$BASE.tar.xz
 if [ -n "$(echo $VERSION | cut -d. -f3)" ] ; then
@@ -9,11 +9,11 @@ fi
    SOURCE_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x/
   SOURCE2_URL[0]=$KERNEL_URL/pub/linux/kernel/v6.x/
   SOURCE2_URL[1]=https://www.kernel.org/pub/linux/kernel/v6.x/
-      SOURCE_VFY=sha256:24fa01fb989c7a3e28453f117799168713766e119c5381dac30115f18f268149
-     SOURCE2_VFY=sha256:cf7dbb88fa35557195f8cde7fd05ec873db95af91cbcae7472a13d9bc9c5cbaa
+      SOURCE_VFY=sha256:774698422ee54c5f1e704456f37c65c06b51b4e9a8b0866f34580d86fef8e226
+     SOURCE2_VFY=sha256:f3166b9b9f6a7dbae9ed7e92e373c8ddb672c5bd2da3991207aa30f52ceda7fa
          WEB_SITE=https://www.kernel.org/
          ENTERED=20111121
-         UPDATED=20240707
+         UPDATED=20240729
            SHORT="The core of a Linux GNU Operating System"
      KEEP_SOURCE=on
            TMPFS=off


### PR DESCRIPTION
This PR needs systemd 254.16 to succeed. See https://github.com/lunar-linux/moonbase-core/pull/3580