### PR TITLE
curl: version bumped to 8.9.1

### DIFF
--- a/ftp/curl/DEPENDS
+++ b/ftp/curl/DEPENDS
@@ -1,5 +1,9 @@
 depends zlib
 
+optional_depends c-ares "--enable-ares" \
+                 "--disable-ares" \
+                 "for using c-ares for DNS lookups"
+
 optional_depends libidn2 "--with-libidn2" \
                  "--without-libidn2" \
                  "for libidn2 support"

--- a/ftp/curl/DETAILS
+++ b/ftp/curl/DETAILS
@@ -1,11 +1,11 @@
           MODULE=curl
-         VERSION=8.8.0
+         VERSION=8.9.1
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=https://curl.se/download/
-      SOURCE_VFY=sha256:0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400
+      SOURCE_VFY=sha256:f292f6cc051d5bbabf725ef85d432dfeacc8711dd717ea97612ae590643801e5
         WEB_SITE=https://curl.se/
          ENTERED=20010922
-         UPDATED=20240523
+         UPDATED=20240731
            SHORT="Tool for transferring files using URL syntax"
 
 cat << EOF


### PR DESCRIPTION
Fixes [CVE-2024-7264](https://www.cvedetails.com/cve/CVE-2024-7264/)