### PR TITLE
dracut: Use local XSLT resources instead of trying to download them

### DIFF
--- a/kernel/dracut/PRE_BUILD
+++ b/kernel/dracut/PRE_BUILD
@@ -16,4 +16,13 @@ fi
 
 default_pre_build &&
 
-sedit 's:dash:bash:' Makefile
+sedit 's:dash:bash:' Makefile &&
+
+if in_depends dracut asciidoc
+then
+    DOCBOOK_XSL_MAN=$(lvu install docbook-xsl | grep "manpages/docbook.xsl$")
+    DOCBOOK_XSL_HTML=$(lvu install docbook-xsl | grep "xhtml/docbook.xsl$")
+
+    sedit "s|http://docbook.*manpages/docbook.xsl|$DOCBOOK_XSL_MAN|" Makefile &&
+    sedit "s|http://docbook.*xhtml/docbook.xsl|$DOCBOOK_XSL_HTML|" Makefile
+fi


### PR DESCRIPTION
The "xsltproc" invocations in the dracut Makefile is trying to use a XSLT stylesheet downloaded from docbook.sourceforge.net (non-SSL HTTP even!). But these stylesheets are already available on the system if asciidoc is installed! So use the local copies instead of trying (and failing) to download them instead.

Now we can finally have man pages for our dracut installations.