### PR TITLE
openssh: version bumped to 9.9p1

### DIFF
--- a/crypto/openssh/CONFIGURE
+++ b/crypto/openssh/CONFIGURE
@@ -1,2 +1,2 @@
-mquery DISABLE_DSA "Disable DSA key support?" n \
+mquery DISABLE_DSA "Disable DSA key support?" y \
         "--disable-dsa-keys" "--enable-dsa-keys"

--- a/crypto/openssh/DETAILS
+++ b/crypto/openssh/DETAILS
@@ -1,13 +1,13 @@
           MODULE=openssh
-         VERSION=9.8p1
+         VERSION=9.9p1
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://ftp3.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable
    SOURCE_URL[1]=ftp://ftp5.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable
    SOURCE_URL[2]=ftp://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable
-      SOURCE_VFY=sha256:dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3
+      SOURCE_VFY=sha256:b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02
         WEB_SITE=http://www.openssh.com/
          ENTERED=20010922
-         UPDATED=20240701
+         UPDATED=20240923
            SHORT="Client and server for encrypted remote logins and file transfers"
 
 cat << EOF


### PR DESCRIPTION
This release now defaults to disabling DSA keys at build time, so change CONFIGURE accordingly.