### PR TITLE
dracut: Switching to dracut-ng, version bump to 103

### DIFF
--- a/kernel/dracut/DETAILS
+++ b/kernel/dracut/DETAILS
@@ -1,12 +1,13 @@
            MODULE=dracut
-          VERSION=059
+          VERSION=103
            SOURCE=$MODULE-$VERSION.tar.gz
-  SOURCE_URL_FULL=https://github.com/dracutdevs/dracut/archive/$VERSION.tar.gz
-       SOURCE_VFY=sha256:eabf0bb685420c1e1d5475b6855ef787104508f0135ff570312845256e0fcecf
+  SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/$VERSION.tar.gz
+  SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/refs/tags/$VERSION.tar.gz
+       SOURCE_VFY=sha256:9a92b4f0643926a65162171d68b9525fc93e6e82f455a4b3938db385a841bda8
  SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
          WEB_SITE=https://dracut.wiki.kernel.org/index.php/Main_Page
           ENTERED=20120715
-          UPDATED=20230306
+          UPDATED=20240928
             SHORT="Initramfs generator using udev"
 COMPRESS_MANPAGES=off # If we compress them it will mess up an upgrade for this module due to symlinks
 

--- a/kernel/dracut/DETAILS
+++ b/kernel/dracut/DETAILS
@@ -4,7 +4,7 @@
   SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/$VERSION.tar.gz
   SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/refs/tags/$VERSION.tar.gz
        SOURCE_VFY=sha256:9a92b4f0643926a65162171d68b9525fc93e6e82f455a4b3938db385a841bda8
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
+ SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-ng-$VERSION
          WEB_SITE=https://dracut.wiki.kernel.org/index.php/Main_Page
           ENTERED=20120715
           UPDATED=20240928


### PR DESCRIPTION
Trying out dracut-ng (as used by Arch Linux) because it seems to have considerably more lively development than the Red Hat one.