### PR TITLE
lvm2: version bumped to 2.03.29

### DIFF
--- a/filesys/lvm2/BUILD
+++ b/filesys/lvm2/BUILD
@@ -1,10 +1,3 @@
-if ! [[ $(arch) == x86_64 ]]; then
-  CFLAGS+=" -fPIE " &&
-  LDFLAGS+=" -pie "
-  sedit 's/CLDFLAGS.*-Wl,-z,relro/& -shared/' libdm/make.tmpl.in
-  sedit 's/CLDFLAGS.*-Wl,-z,relro/& -shared/' make.tmpl.in
-fi
-
 if module_installed systemd; then
   OPTS+=" --with-udev_prefix=/usr \
           --with-systemdsystemunitdir=$(pkg-config systemd --variable=systemdsystemunitdir)"

--- a/filesys/lvm2/DETAILS
+++ b/filesys/lvm2/DETAILS
@@ -1,13 +1,13 @@
           MODULE=lvm2
-         VERSION=2.03.21
+         VERSION=2.03.29
           SOURCE=LVM2.$VERSION.tgz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/LVM2.$VERSION
    SOURCE_URL[0]=https://sourceware.org/pub/lvm2/
    SOURCE_URL[1]=ftp://sources.redhat.com/pub/lvm2/old
-      SOURCE_VFY=sha256:1e261921d621998adc37960c615de784c6145c7f737a80b781f3108fbec67a7e
+      SOURCE_VFY=sha256:30c53776cb4ddf6bf9eca29d0c28dbf9c5ac170c09154321213b11c3dbb5be9c
         WEB_SITE=http://sources.redhat.com/lvm2
          ENTERED=20040511
-         UPDATED=20230731
+         UPDATED=20241210
            SHORT="Logical volume manager"
            PSAFE=no
 LUNAR_RESTART_SERVICES=off


### PR DESCRIPTION
Remove code for non-x86_64 systems since the build on x86 fails with this.