### PR TITLE
file: revert to 5.45, some zip files not recognized

### DIFF
--- a/utils/file/DETAILS
+++ b/utils/file/DETAILS
@@ -1,13 +1,13 @@
           MODULE=file
-         VERSION=5.46
+         VERSION=5.45
           SOURCE=$MODULE-$VERSION.tar.gz
    SOURCE_URL[0]=http://ftp.astron.com/pub/$MODULE
    SOURCE_URL[1]=ftp://ftp.astron.com/pub/$MODULE
    SOURCE_URL[2]=https://fossies.org/linux/misc/
-      SOURCE_VFY=sha256:c9cc77c7c560c543135edc555af609d5619dbef011997e988ce40a3d75d86088
+      SOURCE_VFY=sha256:fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82
         WEB_SITE=http://www.darwinsys.com/file/
          ENTERED=20010922
-         UPDATED=20241203
+         UPDATED=20241220
            SHORT="File attempts to classify files by their content"
 
 cat << EOF


### PR DESCRIPTION
File 5.46 returns "data" for some zip archives, like sqlite and brave-bin. The issue is it downloads the archive, but then goes to the fallback mirror and fails. The actual call is in /var/lib/lunar/functions/download.lunar and the 'file -b' output is supposed to contain "Zip" but now it's "data".

See the bug tracking thread on https://bugs.astron.com/view.php?id=571 . Apparently it's been fixed on the main branch and we're waiting for 5.47.