### PR TITLE
bash_static: Add glibc version checks to disable bash's getenv...

### DIFF
--- a/shells/bash_static/BUILD
+++ b/shells/bash_static/BUILD
@@ -7,6 +7,13 @@ OPTS+=" --bindir=/usr/bin \
         --enable-static-link \
         --without-bash-mallocx"
 
+GLIBC_MINOR_VERSION=$(lvu installed glibc | cut -f2 -d.)
+
+if (( GLIBC_MINOR_VERSION >= 41 ))
+then
+	sedit '/CAN_REDEFINE_GETENV/s,$,//,' config.h.in
+fi
+
 default_config &&
 make version.h &&
 make &&

--- a/shells/bash_static/DETAILS
+++ b/shells/bash_static/DETAILS
@@ -9,7 +9,7 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/bash-$BASE_VERSION
       SOURCE_VFY=sha256:cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa
         WEB_SITE=http://tiswww.case.edu/php/chet/bash_static/bashtop.html
          ENTERED=20020615
-         UPDATED=20220117
+         UPDATED=20250201
            SHORT="A static bash build for rescue purposes"
 
 cat << EOF


### PR DESCRIPTION
...when compiling with glibc 2.41 or higher, that is

(glibc already has a perfectly good getenv.)