### PR TITLE
binutils: version bumped to 2.44 + remove gold

### DIFF
--- a/devel/binutils/BUILD
+++ b/devel/binutils/BUILD
@@ -18,7 +18,6 @@ fi &&
              --disable-readline \
              --disable-sim \
              --enable-cet \
-             --enable-gold \
              --enable-relro \
              --enable-plugins \
              --enable-threads \

--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -1,12 +1,12 @@
           MODULE=binutils
-         VERSION=2.43.1
+         VERSION=2.44
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd
+      SOURCE_VFY=sha256:ce2017e059d63e67ddb9240e9d4ec49c2893605035cd60e92ad53177f4377237
         WEB_SITE=http://sources.redhat.com/binutils
          ENTERED=20010922
-         UPDATED=20240820
+         UPDATED=20250207
            SHORT="An essential collection of binary utilities"
 
 cat << EOF


### PR DESCRIPTION
More infos about the gold linker removal here: https://www.phoronix.com/news/GNU-Gold-Linker-Deprecated