### PR TITLE
kernel-headers: version bumped to 6.14.1

### DIFF
--- a/kernel/kernel-headers/DETAILS.x86_64
+++ b/kernel/kernel-headers/DETAILS.x86_64
@@ -1,12 +1,12 @@
             MODULE=kernel-headers
-           VERSION=6.13.1
+           VERSION=6.14.1
             SOURCE=kernel-headers-$VERSION-x86_64.tar.bz2
   SOURCE_DIRECTORY=${BUILD_DIRECTORY}/kernel-headers-$VERSION-x86_64
         SOURCE_URL=$MIRROR_URL
-        SOURCE_VFY=sha256:abfb1972301d6285dd6c16c3d155879f1763a076ae10d3dd5645f44fbc868395
+        SOURCE_VFY=sha256:1cae1329d61b9a3f84ad7ef764ebf88721e7f4a00948c88711ba356b72543231
           WEB_SITE=http://www.lunar-linux.org/
            ENTERED=20040226
-           UPDATED=20250202
+           UPDATED=20250407
             SHORT="Sanitized kernel headers for userspace"
 
 cat << EOF


### PR DESCRIPTION
Headers tarball here: https://hobby.esselfe.ca/src/kernel-headers-6.14.1-x86_64.tar.bz2