### PR TITLE
ntfs-3g: Removing fuse optional_depends and go with internal as noted

### DIFF
--- a/filesys/ntfs-3g/BUILD
+++ b/filesys/ntfs-3g/BUILD
@@ -1,10 +1,19 @@
+sed 's|$(DESTDIR)/sbin|$(DESTDIR)/usr/bin|' -i {ntfsprogs,src}/Makefile.in &&
+autoreconf -fiv &&
+#export LIBGCRYPT_LIBS="-lgcrypt"
 
+# Use fuse internal,see https://bugs.gentoo.org/822024
 OPTS+=" --enable-extras     \
+        --with-uuid \
         --enable-ntfsprogs  \
         --disable-ldconfig  \
         --disable-static    \
+        --enable-posix-acls \
+        --enable-xattr-mappings \
         --mandir=/usr/share/man \
-        --without-hd  \
+        --sbin=/usr/bin \
+        --without-hd \
+        --with-fuse=internal \
         --exec-prefix=/usr" &&
 
 default_build

--- a/filesys/ntfs-3g/DEPENDS
+++ b/filesys/ntfs-3g/DEPENDS
@@ -1,5 +1,6 @@
+depends libgcrypt
+
 optional_depends attr       "--enable-xattr-mappings" "--disable-xattr-mappings"   "For extended attributes mappings support" y
 optional_depends acl        "--enable-posix-acls "    "--disable-posix-acls"       "For POSIX ACL support" n
 optional_depends util-linux "--with-uuid"             "--without-uuid"             "To generate DCE compliant UUIDs" y
-optional_depends fuse       "--with-fuse=external"    "--with-fuse=internal"       "If yes, use system provided fuse, else internal is used" n
-optional_depends gnutls     "--enable-crypto"         "--disable-crypto"           "For encrypted disk support" n
+optional_depends gnutls     "--enable-crypto"         "--disable-crypto"           "For encrypted disk support"


### PR DESCRIPTION
in BUILD. Do a autoreconf so it will properly fine libgcrypt.