### PR TITLE
python: POST_INSTALL should always exit with success

### DIFF
--- a/python/python/POST_INSTALL
+++ b/python/python/POST_INSTALL
@@ -9,4 +9,6 @@ if query "Do you want lunar to attempt to upgrade your Python modules?" ${ASK_FO
   for PYTHONMOD in $(sort_by_dependency $PYTHONMODS); do
     lin -c $PYTHONMOD || true
   done
+else
+  true # don't prevent the next lin from running
 fi


### PR DESCRIPTION
Currently if you answer "n" to the query to upgrade Python modules, the POST_INSTALL exits with 1 and lin aborts. This is a problem when you're trying to lin something with Python as a dependency.