### PR TITLE
zstd: No version bump, just using cmake instead so various *.cmake

### DIFF
--- a/archive/zstd/BUILD
+++ b/archive/zstd/BUILD
@@ -1,9 +1,18 @@
-make &&
-make zstdmt &&
-make -C contrib/pzstd &&
+cd build/cmake
 
-prepare_install &&
+OPTS+=" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DZSTD_ZLIB_SUPPORT=ON \
+        -DZSTD_LZ4_SUPPORT=ON \
+        -DZSTD_BUILD_CONTRIB=ON \
+        -DZSTD_BUILD_STATIC=OFF \
+        -DZSTD_BUILD_TESTS=OFF \
+        -DZSTD_PROGRAMS_LINK_SHARED=ON \
+        -Wno-dev"
 
-make PREFIX=/usr install &&
-ln -f /usr/bin/zstd /usr/bin/zstdmt &&
-install -Dm755 contrib/pzstd/pzstd /usr/bin/pzstd
+cmake -B $MODULE-$VERSION -S . -G Ninja $OPTS &&
+cmake --build $MODULE-$VERSION &&
+
+prepare_install
+cmake --install $MODULE-$VERSION

--- a/archive/zstd/DEPENDS
+++ b/archive/zstd/DEPENDS
@@ -1,3 +1,5 @@
 depends xz
 depends lz4
 depends zlib
+
+optional_depends lzma-sdk "-DZSTD_LZMA_SUPPORT=ON" "-DZSTD_LZMA_SUPPORT=OFF" "for lzma archiving support"

--- a/archive/zstd/DEPENDS
+++ b/archive/zstd/DEPENDS
@@ -1,5 +1,6 @@
 depends xz
 depends lz4
 depends zlib
+depends cmake
 
 optional_depends lzma-sdk "-DZSTD_LZMA_SUPPORT=ON" "-DZSTD_LZMA_SUPPORT=OFF" "for lzma archiving support"


### PR DESCRIPTION
files get created and installed for those apps looking for them. Also added lzma-sdk as an optional_depends.