### PR TITLE
gmp: Patch the configure script to work with gcc 15

### DIFF
--- a/libs/gmp/BUILD
+++ b/libs/gmp/BUILD
@@ -1,10 +1,11 @@
 OPTS="--enable-cxx --enable-fat --disable-static"
+LIBTOOL=/usr/bin/libtool
 
+autoconf &&
 default_config &&
-sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool &&
-make &&
-make check &&
+make LIBTOOL=$LIBTOOL &&
+make check LIBTOOL=$LIBTOOL &&
 prepare_install &&
-make install &&
+make install LIBTOOL=$LIBTOOL &&
 
 ln -sf /usr/lib/libgmp.so /usr/lib/libgmp.so.3

--- a/libs/gmp/patch.d/gcc-15.patch
+++ b/libs/gmp/patch.d/gcc-15.patch
@@ -1,0 +1,16 @@
+diff -C 2 -r gmp-6.3.0.orig/acinclude.m4 gmp-6.3.0/acinclude.m4
+*** gmp-6.3.0.orig/acinclude.m4	2023-07-29 22:42:16.000000000 +0900
+--- gmp-6.3.0/acinclude.m4	2025-08-21 16:16:36.115376807 +0900
+***************
+*** 610,614 ****
+  #if defined (__GNUC__) && ! defined (__cplusplus)
+  typedef unsigned long long t1;typedef t1*t2;
+! void g(){}
+  void h(){}
+  static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+--- 610,614 ----
+  #if defined (__GNUC__) && ! defined (__cplusplus)
+  typedef unsigned long long t1;typedef t1*t2;
+! void g(int a,const t1 *b,const t1 c,const t1 *d,const t1 *e,int f){}
+  void h(){}
+  static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)


### PR DESCRIPTION
The irony is that this particular snippet of C code is meant to trigger a core dump on gcc 3 on Darwin, so I could probably do away with the entire thing altogether, but that would be too much work to bother with.

So I'll just fix this one bit of code which is deliberately broken anyway.