### PR TITLE
dracut: Version bumped to 110

### DIFF
--- a/kernel/dracut/DETAILS
+++ b/kernel/dracut/DETAILS
@@ -1,14 +1,13 @@
-           MODULE=dracut
-          VERSION=106
-           SOURCE=$MODULE-$VERSION.tar.gz
-  SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/$VERSION.tar.gz
-  SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/refs/tags/$VERSION.tar.gz
-       SOURCE_VFY=sha256:9009ac13072c9b583822ad1a17f2cca47af463190f0d6623e90b0f1107c71f95
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-ng-$VERSION
-         WEB_SITE=https://dracut.wiki.kernel.org/index.php/Main_Page
-          ENTERED=20120715
-          UPDATED=20250307
-            SHORT="Initramfs generator using udev"
+          MODULE=dracut
+         VERSION=110
+          SOURCE=$MODULE-$VERSION.tar.gz
+ SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/refs/tags/$VERSION.tar.gz
+      SOURCE_VFY=sha256:0d357853f8cf2371d89a8ebcbbb1fd2c1c85a79d8866925fd7385eaeb20a27dc
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-ng-$VERSION
+        WEB_SITE=https://dracut.wiki.kernel.org/index.php/Main_Page
+         ENTERED=20120715
+         UPDATED=20260312
+           SHORT="Initramfs generator using udev"
 COMPRESS_MANPAGES=off # If we compress them it will mess up an upgrade for this module due to symlinks
 
 cat << EOF


### PR DESCRIPTION
Upgrade dracut from version 106 to 110

- Updated VERSION to 110
- Updated SOURCE_VFY to sha256:0d357853f8cf2371d89a8ebcbbb1fd2c1c85a79d8866925fd7385eaeb20a27dc
- Updated UPDATED timestamp to 20260312
- No changes to dependencies or build procedures

---
*Automated PR created by n8n + Claude AI*