### PR TITLE
openssl: version bumped to 3.6.2

### DIFF
--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -1,20 +1,20 @@
-          MODULE=openssl
-         VERSION=3.6.2
-          SOURCE=$MODULE-$VERSION.tar.gz
-         SOURCE2=Makefile.openssl-certs
-   SOURCE_URL[0]=https://github.com/$MODULE/$MODULE/releases/download/${MODULE}-${VERSION}/
-   SOURCE_URL[1]=ftp://opensores.thebunker.net/pub/mirrors/openssl/source
-   SOURCE_URL[2]=http://www.dentarthurdent.com/transfer/openssl
-   SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
-   SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
-     SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
-     SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
-        WEB_SITE=http://www.openssl.org
-         ENTERED=20010922
-         UPDATED=20260409
-           PSAFE="no"
-           SHORT="A library for providing encrypted transport layers"
+       MODULE=openssl
+      VERSION=3.6.2
+       SOURCE=$MODULE-$VERSION.tar.gz
+      SOURCE2=Makefile.openssl-certs
+SOURCE_URL[0]=https://github.com/$MODULE/$MODULE/releases/download/${MODULE}-${VERSION}/
+SOURCE_URL[1]=ftp://opensores.thebunker.net/pub/mirrors/openssl/source
+SOURCE_URL[2]=http://www.dentarthurdent.com/transfer/openssl
+SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
+SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
+  SOURCE2_URL=$PATCH_URL
+   SOURCE_VFY=sha256:aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
+  SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
+     WEB_SITE=http://www.openssl.org
+      ENTERED=20010922
+      UPDATED=20260409
+        SHORT="A library for providing encrypted transport layers"
+PSAFE="no"
 
 cat << EOF
 The OpenSSL Project is a collaborative effort to develop a robust, commercial-

--- a/crypto/openssl/DETAILS
+++ b/crypto/openssl/DETAILS
@@ -1,5 +1,5 @@
           MODULE=openssl
-         VERSION=3.6.0
+         VERSION=3.6.2
           SOURCE=$MODULE-$VERSION.tar.gz
          SOURCE2=Makefile.openssl-certs
    SOURCE_URL[0]=https://github.com/$MODULE/$MODULE/releases/download/${MODULE}-${VERSION}/
@@ -8,11 +8,11 @@
    SOURCE_URL[3]=ftp://ftp.infoscience.co.jp/pub/Crypto/SSL/openssl/source
    SOURCE_URL[4]=ftp://ftp.duth.gr/pub/OpenSSL/source
      SOURCE2_URL=$PATCH_URL
-      SOURCE_VFY=sha256:b6a5f44b7eb69e3fa35dbf15524405b44837a481d43d81daddde3ff21fcbb8e9
+      SOURCE_VFY=sha256:aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
      SOURCE2_VFY=sha256:9b44b0bfac91672a3249e70484d036924ca528b4f704ff7ef2a9b46413d2afab
         WEB_SITE=http://www.openssl.org
          ENTERED=20010922
-         UPDATED=20251212
+         UPDATED=20260409
            PSAFE="no"
            SHORT="A library for providing encrypted transport layers"
 


### PR DESCRIPTION
Fixes these CVEs:
 - CVE-2026-31790 Fixed incorrect failure handling in RSA KEM RSASVE encapsulation.
 - CVE-2026-2673 Fixed loss of key agreement group tuple structure when the DEFAULT keyword is used in the server-side configuration of the key-agreement group list.
 - CVE-2026-28386 Fixed out-of-bounds read in AES-CFB-128 on x86-64 CPUs with AVX-512 support.
 - CVE-2026-28387 Fixed potential use-after-free in DANE client code.
 - CVE-2026-28388 Fixed NULL pointer dereference when processing a delta CRL.
 - CVE-2026-28389 Fixed possible NULL dereference when processing CMS KeyAgreeRecipientInfo.
 - CVE-2026-28390 Fixed possible NULL dereference when processing CMS KeyTransportRecipientInfo.
 - CVE-2026-31789 Fixed heap buffer overflow in hexadecimal conversion.