### PR TITLE
libgcrypt: Version bumped to 1.12.2

### DIFF
--- a/crypto/libgcrypt/DETAILS
+++ b/crypto/libgcrypt/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libgcrypt
-         VERSION=1.12.1
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
-      SOURCE_VFY=sha256:7df5c08d952ba33f9b6bdabdb06a61a78b2cf62d2122c2d1d03a91a79832aa3c
-        WEB_SITE=https://directory.fsf.org/wiki/Security/libgcrypt
-         ENTERED=20020212
-         UPDATED=20260319
-           SHORT="General purpose crypto library"
+    MODULE=libgcrypt
+   VERSION=1.12.2
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
+SOURCE_VFY=sha256:7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e
+  WEB_SITE=https://directory.fsf.org/wiki/Security/libgcrypt
+   ENTERED=20020212
+   UPDATED=20260415
+     SHORT="General purpose crypto library"
 
 cat << EOF
 Libgcrypt is a general purpose crypto library based on the code used


### PR DESCRIPTION
Upgrade libgcrypt from 1.12.1 to 1.12.2

- Updated VERSION to 1.12.2
- Updated SOURCE_VFY to sha256:7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e
- Updated UPDATED date to 20260415

---
*Automated PR created by n8n + Claude AI*