### PR TITLE
timezone-data: Version bumped to 2026b

### DIFF
--- a/utils/timezone-data/DETAILS
+++ b/utils/timezone-data/DETAILS
@@ -1,18 +1,18 @@
-          MODULE=timezone-data
-           TZONE=c
-         VERSION=2025$TZONE
-          SOURCE=tzdata$VERSION.tar.gz
-         SOURCE2=tzcode$VERSION.tar.gz
-   SOURCE_URL[0]=https://www.iana.org/time-zones/repository/releases
-   SOURCE_URL[1]=$MIRROR_URL
-  SOURCE2_URL[0]=https://www.iana.org/time-zones/repository/releases
-  SOURCE2_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:4aa79e4effee53fc4029ffe5f6ebe97937282ebcdf386d5d2da91ce84142f957
-     SOURCE2_VFY=sha256:697ebe6625444aef5080f58e49d03424bbb52e08bf483d3ddb5acf10cbd15740
-        WEB_SITE=ftp://munnari.oz.au/pub
-         ENTERED=20070203
-         UPDATED=20251212
-           SHORT="Timezone data and utilities"
+        MODULE=timezone-data
+         TZONE=b
+       VERSION=2026$TZONE
+        SOURCE=tzdata$VERSION.tar.gz
+       SOURCE2=tzcode$VERSION.tar.gz
+ SOURCE_URL[0]=https://www.iana.org/time-zones/repository/releases
+ SOURCE_URL[1]=$MIRROR_URL
+SOURCE2_URL[0]=https://www.iana.org/time-zones/repository/releases
+SOURCE2_URL[1]=$MIRROR_URL
+    SOURCE_VFY=sha256:114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544
+   SOURCE2_VFY=sha256:37e9ed8427f5d3521c22fc58e293cbfb043d70eedf1003870b33f363f61ca344
+      WEB_SITE=ftp://munnari.oz.au/pub
+       ENTERED=20070203
+       UPDATED=20260424
+         SHORT="Timezone data and utilities"
 
 cat << EOF
 Timezone-data contains the timezone data (/usr/share/zoneinfo/*) and various


### PR DESCRIPTION
Upgrade timezone-data to version 2026b

- Updated tzdata to 2026b
- Updated tzcode to 2026b
- Updated SOURCE_VFY and SOURCE2_VFY checksums
- Updated UPDATED date to 20260424

---
*Automated PR created by n8n + Claude AI*