### PR TITLE
libgpg-error: Version bumped to 1.60

### DIFF
--- a/crypto/libgpg-error/DETAILS
+++ b/crypto/libgpg-error/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libgpg-error
-         VERSION=1.59
-          SOURCE=$MODULE-$VERSION.tar.bz2
-      SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/$MODULE
-      SOURCE_VFY=sha256:a19bc5087fd97026d93cb4b45d51638d1a25202a5e1fbc3905799f424cfa6134
-        WEB_SITE=http://www.gnupg.org
-         ENTERED=20020212
-         UPDATED=20260219
-           SHORT="Defines common error values for all GnuPG components"
+    MODULE=libgpg-error
+   VERSION=1.60
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://www.gnupg.org/ftp/gcrypt/$MODULE
+SOURCE_VFY=sha256:11b2a738e212f3eab0fe8637bc341d3181ca964e97bb2654de91aab7dae4ce09
+  WEB_SITE=http://www.gnupg.org
+   ENTERED=20020212
+   UPDATED=20260424
+     SHORT="Defines common error values for all GnuPG components"
 
 cat << EOF
 This is a library that defines common error values for all GnuPG components.


### PR DESCRIPTION
Upgrade libgpg-error from version 1.59 to 1.60. This update includes the latest error definitions for GnuPG components.

---
*Automated PR created by n8n + Claude AI*