### PR TITLE
ccache: Version bumped to 4.13.5

### DIFF
--- a/utils/ccache/DETAILS
+++ b/utils/ccache/DETAILS
@@ -1,11 +1,11 @@
     MODULE=ccache
-   VERSION=4.13.3
+   VERSION=4.13.5
     SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_URL=https://github.com/ccache/ccache/releases/download/v$VERSION/
-SOURCE_VFY=sha256:c149d71f47f6fe08e4f2e43db4b0b091c61e8ea3daa23aa998b094bd84ecdfe8
+SOURCE_VFY=sha256:2fb4896269a1ef15da99ba940ac1478b38f2c4b720797205860bf40364f37d37
   WEB_SITE=https://ccache.dev/
    ENTERED=20020701
-   UPDATED=20260413
+   UPDATED=20260426
      SHORT="A compiler cache"
 
 cat << EOF


### PR DESCRIPTION
Upgrade ccache from version 4.13.3 to 4.13.5

- Updated VERSION to 4.13.5
- Updated SOURCE_VFY to sha256:2fb4896269a1ef15da99ba940ac1478b38f2c4b720797205860bf40364f37d37
- Updated UPDATED date to 20260426

---
*Automated PR created by n8n + Claude AI*