### PR TITLE
ethtool: Version bumped to 7.0

### DIFF
--- a/net/ethtool/DETAILS
+++ b/net/ethtool/DETAILS
@@ -1,15 +1,16 @@
-          MODULE=ethtool
-         VERSION=6.15
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=$KERNEL_URL/pub/software/network/$MODULE
-      SOURCE_VFY=sha256:9477c365114d910120aaec5336a1d16196c833d8486f7c6da67bedef57880ade
-        WEB_SITE=https://www.kernel.org/pub/software/network/ethtool
-         ENTERED=20031026
-         UPDATED=20250910
-           SHORT="Ethernet diagnostic and tuning tool"
+    MODULE=ethtool
+   VERSION=7.0
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=$KERNEL_URL/pub/software/network/$MODULE
+SOURCE_VFY=sha256:660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162
+  WEB_SITE=https://www.kernel.org/pub/software/network/ethtool
+   ENTERED=20031026
+   UPDATED=20260428
+     SHORT="Ethernet diagnostic and tuning tool"
 
 cat << EOF
 Ethtool is a Linux net driver diagnostic and tuning tool for the Linux series of
 kernels. It obtains information and diagnostics related to media, link status,
-driver version, PCI (or other) bus location, and more. Ethtool obsoletes mii-tool.
+driver version, PCI (or other) bus location, and more. Ethtool obsoletes
+mii-tool.
 EOF


### PR DESCRIPTION
Update ethtool from version 6.15 to 7.0

- Version: 6.15 → 7.0
- Source: https://cdn.kernel.org//pub/software/network/ethtool/ethtool-7.0.tar.xz
- SHA256: 660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162

---
*Automated PR created by n8n + Claude AI*