### PR TITLE
glib-2: Version bumped to 2.88.1

### DIFF
--- a/libs/glib-2/DETAILS
+++ b/libs/glib-2/DETAILS
@@ -1,13 +1,13 @@
           MODULE=glib-2
-         VERSION=2.87.2
+         VERSION=2.88.1
           SOURCE=${MODULE%-*}-$VERSION.tar.xz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/${MODULE%-*}-$VERSION
       SOURCE_URL=$GNOME_URL/sources/glib/${VERSION%.*}
-      SOURCE_VFY=sha256:d6eb74a4f4ffc0b56df79ae3a939463b1d92c623f6c167d51aab24e303a851f3
+      SOURCE_VFY=sha256:51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e
         WEB_SITE=http://library.gnome.org/devel/glib
         REPLACES=gdbus-codegen
          ENTERED=20020313
-         UPDATED=20260124
+         UPDATED=20260502
            SHORT="A library of useful C routines for trees, hashes, and lists"
 
 cat << EOF


### PR DESCRIPTION
Upgrade glib-2 from version 2.87.2 to 2.88.1. Updated SOURCE_VFY hash and UPDATED date.

---
*Automated PR created by n8n + Claude AI*