### PR TITLE
libusb: Version bumped to 1.0.30

### DIFF
--- a/libs/libusb/DETAILS
+++ b/libs/libusb/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libusb
-         VERSION=1.0.29
+         VERSION=1.0.30
           SOURCE=$MODULE-$VERSION.tar.gz
  SOURCE_URL_FULL=https://github.com/libusb/libusb/archive/refs/tags/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:7c2dd39c0b2589236e48c93247c986ae272e27570942b4163cb00a060fcf1b74
+      SOURCE_VFY=sha256:2ae28adb0bb9558c86135c4e1c11b320b0805461e207a64a6e520a114094bf07
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
         WEB_SITE=http://libusb.org/
          ENTERED=20140106
-         UPDATED=20251206
+         UPDATED=20260518
            SHORT="Library that provides generic access to USB devices"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libusb from 1.0.29 to 1.0.30

- Updated VERSION to 1.0.30
- Updated SOURCE_VFY to sha256:2ae28adb0bb9558c86135c4e1c11b320b0805461e207a64a6e520a114094bf07
- Updated UPDATED date to 20260518
- All other module attributes preserved

---
*Automated PR created by n8n + Claude AI*