### PR TITLE
libressl: Version bumped to 4.3.2

### DIFF
--- a/crypto/libressl/DETAILS
+++ b/crypto/libressl/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=libressl
-         VERSION=4.1.0
-          SOURCE=$MODULE-$VERSION.tar.gz
-      SOURCE_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/
-      SOURCE_VFY=sha256:0f71c16bd34bdaaccdcb96a5d94a4921bfb612ec6e0eba7a80d8854eefd8bb61
-        WEB_SITE=https://www.libressl.org
-         ENTERED=20160301
-         UPDATED=20250912
-           SHORT="A version of the TLS/crypto stack forked from OpenSSL"
+    MODULE=libressl
+   VERSION=4.3.2
+    SOURCE=$MODULE-$VERSION.tar.gz
+SOURCE_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/
+SOURCE_VFY=sha256:edf01aee24c65d69e6a9efcb9d44bcda682ff9d4f3bbbd95e794e1dfa90847b5
+  WEB_SITE=https://www.libressl.org
+   ENTERED=20160301
+   UPDATED=20260526
+     SHORT="A version of the TLS/crypto stack forked from OpenSSL"
 
 cat << EOF
 LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014,


### PR DESCRIPTION
Upgrade libressl from 4.1.0 to 4.3.2

- Version: 4.1.0 → 4.3.2
- SHA256: edf01aee24c65d69e6a9efcb9d44bcda682ff9d4f3bbbd95e794e1dfa90847b5
- Updated: 20260526

---
*Automated PR created by n8n + Claude AI*