### PR TITLE
binutils: Version bumped to 2.46.0

### DIFF
--- a/devel/binutils/DETAILS
+++ b/devel/binutils/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=binutils
-         VERSION=2.45.1
-          SOURCE=$MODULE-$VERSION.tar.xz
-   SOURCE_URL[0]=$GNU_URL/$MODULE
-   SOURCE_URL[1]=$MIRROR_URL
-      SOURCE_VFY=sha256:5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5
-        WEB_SITE=http://sources.redhat.com/binutils
-         ENTERED=20010922
-         UPDATED=20251113
-           SHORT="An essential collection of binary utilities"
+       MODULE=binutils
+      VERSION=2.46.0
+       SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL[0]=$GNU_URL/$MODULE
+SOURCE_URL[1]=$MIRROR_URL
+   SOURCE_VFY=sha256:d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2
+     WEB_SITE=http://sources.redhat.com/binutils
+      ENTERED=20010922
+      UPDATED=20260609
+        SHORT="An essential collection of binary utilities"
 
 cat << EOF
 binutils is a collection of binary utilities:


### PR DESCRIPTION
Upgrade binutils from 2.45.1 to 2.46.0. SHA256 checksum verified and UPDATED timestamp set to 20260609.

---
*Automated PR created by n8n + Claude AI*