### PR TITLE
btrfs-progs: Version bumped to 7.0

### DIFF
--- a/filesys/btrfs-progs/DETAILS
+++ b/filesys/btrfs-progs/DETAILS
@@ -1,12 +1,12 @@
           MODULE=btrfs-progs
-         VERSION=6.19.1
+         VERSION=7.0
           SOURCE=$MODULE-$VERSION.tar.gz
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-$VERSION
  SOURCE_URL_FULL=https://github.com/kdave/btrfs-progs/archive/v$VERSION.tar.gz
-      SOURCE_VFY=sha256:3213ab1c1f92a75ff181a08009bbb66a4899e168fdb57ca92a5f3045835e169c
+      SOURCE_VFY=sha256:315e05569f93a595533158cb6bcca526509f519b5be1948b53525a7cb9c046b5
         WEB_SITE=https://btrfs.readthedocs.io/en/latest/
          ENTERED=20090819
-         UPDATED=20260318
+         UPDATED=20260609
            SHORT="btrfs userspace tools"
 
 cat << EOF


### PR DESCRIPTION
Upgrade btrfs-progs from version 6.19.1 to 7.0. This release is available from the official GitHub repository and includes the latest improvements and bug fixes to the btrfs userspace tools.

---
*Automated PR created by n8n + Claude AI*