### PR TITLE
iptables: Version bumped to 1.8.13

### DIFF
--- a/security/iptables/DETAILS
+++ b/security/iptables/DETAILS
@@ -1,13 +1,13 @@
-          MODULE=iptables
-         VERSION=1.8.11
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://www.netfilter.org/projects/iptables/files/
-      SOURCE_VFY=sha256:d87303d55ef8c92bcad4dd3f978b26d272013642b029425775f5bad1009fe7b2
-        WEB_SITE=http://www.netfilter.org
-         ENTERED=20010922
-         UPDATED=20250320
-           SHORT="Tool to create netfilter rules"
-           PSAFE=no
+    MODULE=iptables
+   VERSION=1.8.13
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://www.netfilter.org/projects/iptables/files/
+SOURCE_VFY=sha256:1afcd33da9e8f913ace6a2126788162e207e26f5d5e29c6573c0e581ffc58b99
+  WEB_SITE=http://www.netfilter.org
+   ENTERED=20010922
+   UPDATED=20260609
+     SHORT="Tool to create netfilter rules"
+PSAFE=no
 
 cat << EOF
 iptables is built on top of netfilter: the new packet alteration framework


### PR DESCRIPTION
Upgrade iptables from 1.8.11 to 1.8.13. This patch release includes bug fixes and improvements to the netfilter packet filtering framework.

---
*Automated PR created by n8n + Claude AI*