### PR TITLE
kbd: Version bumped to 2.10.0

### DIFF
--- a/utils/kbd/DETAILS
+++ b/utils/kbd/DETAILS
@@ -1,12 +1,12 @@
-          MODULE=kbd
-         VERSION=2.9.0
-          SOURCE=$MODULE-$VERSION.tar.xz
-      SOURCE_URL=https://www.kernel.org/pub/linux/utils/$MODULE/
-      SOURCE_VFY=sha256:fb3197f17a99eb44d22a3a1a71f755f9622dd963e66acfdea1a45120951b02ed
-        WEB_SITE=https://kbd-project.org
-         ENTERED=20040217
-         UPDATED=20250905
-           SHORT="kbd allows you to configure and manipulate Linux consoles"
+    MODULE=kbd
+   VERSION=2.10.0
+    SOURCE=$MODULE-$VERSION.tar.xz
+SOURCE_URL=https://www.kernel.org/pub/linux/utils/$MODULE/
+SOURCE_VFY=sha256:6e5ca4f8d76ee9e3a8db700b667f13e12aac9933828a64e1aaad93d26be9b479
+  WEB_SITE=https://kbd-project.org
+   ENTERED=20040217
+   UPDATED=20260609
+     SHORT="kbd allows you to configure and manipulate Linux consoles"
 
 cat << EOF
 The kbd package allows you to set-up and manipulate the Linux console


### PR DESCRIPTION
Upgrade kbd from 2.9.0 to 2.10.0

- Updated VERSION to 2.10.0
- Updated SOURCE_VFY to sha256:6e5ca4f8d76ee9e3a8db700b667f13e12aac9933828a64e1aaad93d26be9b479
- Updated UPDATED timestamp to 20260609

---
*Automated PR created by n8n + Claude AI*