### PR TITLE
libmd: Version bumped to 1.2.0

### DIFF
--- a/libs/libmd/DETAILS
+++ b/libs/libmd/DETAILS
@@ -1,11 +1,11 @@
          MODULE=libmd
-        VERSION=1.1.0
+        VERSION=1.2.0
          SOURCE=$MODULE-$VERSION.tar.xz
      SOURCE_URL=https://libbsd.freedesktop.org/releases/
-     SOURCE_VFY=sha256:1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332
+     SOURCE_VFY=sha256:ac15ffb8430502fbaccdec66c5a82ee0eab0b0f36220df56710feadfeb13d0a0
        WEB_SITE=https://www.hadrons.org/software/libmd/
         ENTERED=20210810
-        UPDATED=20230808
+        UPDATED=20260609
           SHORT="Message Digest functions from BSD systems"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libmd from 1.1.0 to 1.2.0

- Updated VERSION to 1.2.0
- Updated SOURCE_VFY to ac15ffb8430502fbaccdec66c5a82ee0eab0b0f36220df56710feadfeb13d0a0
- Updated UPDATED date to 20260609
- All other module properties preserved

---
*Automated PR created by n8n + Claude AI*