### PR TITLE
userspace-rcu: Version bumped to 0.15.6

### DIFF
--- a/libs/userspace-rcu/DETAILS
+++ b/libs/userspace-rcu/DETAILS
@@ -1,12 +1,12 @@
-      MODULE=userspace-rcu
-     VERSION=0.15.5
-      SOURCE=$MODULE-$VERSION.tar.bz2
-  SOURCE_URL=https://lttng.org/files/urcu/
-  SOURCE_VFY=sha256:b2f787a8a83512c32599e71cdabcc5131464947b82014896bd11413b2d782de1
-    WEB_SITE=https://lttng.org/urcu/
-     ENTERED=20150626
-     UPDATED=20251208
-       SHORT="Userspace RCU (read-copy-update) library"
+    MODULE=userspace-rcu
+   VERSION=0.15.6
+    SOURCE=$MODULE-$VERSION.tar.bz2
+SOURCE_URL=https://lttng.org/files/urcu/
+SOURCE_VFY=sha256:850b192096eb11ebf2c70e8f97bc7da7479ee41da1bebeb44e3986908bac414f
+  WEB_SITE=https://lttng.org/urcu/
+   ENTERED=20150626
+   UPDATED=20260609
+     SHORT="Userspace RCU (read-copy-update) library"
 
 cat << EOF
 Liburcu is a LGPLv2.1 userspace RCU (read-copy-update) library. This data


### PR DESCRIPTION
Upgrade userspace-rcu from 0.15.5 to 0.15.6. This update includes the latest improvements and bug fixes from the LTTng userspace RCU library.

---
*Automated PR created by n8n + Claude AI*