### PR TITLE
util-linux: Version bumped to 2.42.1

### DIFF
--- a/utils/util-linux/DETAILS
+++ b/utils/util-linux/DETAILS
@@ -1,11 +1,11 @@
     MODULE=util-linux
-   VERSION=2.42
+   VERSION=2.42.1
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=$KERNEL_URL/pub/linux/utils/$MODULE/v${VERSION::4}
-SOURCE_VFY=sha256:3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9
+SOURCE_VFY=sha256:82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f
   WEB_SITE=https://github.com/util-linux/util-linux
    ENTERED=20010922
-   UPDATED=20260403
+   UPDATED=20260609
      SHORT="Essential utilities for any Linux box"
 
 cat << EOF


### PR DESCRIPTION
Upgrade util-linux from 2.42 to 2.42.1

- Version: 2.42 → 2.42.1
- SHA256: 82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f
- Source: https://cdn.kernel.org//pub/linux/utils/util-linux/v2.42/util-linux-2.42.1.tar.xz

---
*Automated PR created by n8n + Claude AI*