### PR TITLE
dracut: fixed sha256sum, build directory

### DIFF
--- a/kernel/dracut/DETAILS
+++ b/kernel/dracut/DETAILS
@@ -1,10 +1,8 @@
            MODULE=dracut
           VERSION=106
            SOURCE=$MODULE-$VERSION.tar.gz
-  SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/$VERSION.tar.gz
   SOURCE_URL_FULL=https://github.com/dracut-ng/dracut-ng/archive/refs/tags/$VERSION.tar.gz
-       SOURCE_VFY=sha256:9009ac13072c9b583822ad1a17f2cca47af463190f0d6623e90b0f1107c71f95
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/$MODULE-ng-$VERSION
+       SOURCE_VFY=sha256:29dafe990036ebbfee996208ff4445fcbd60fef625b430a2f966d099d5c07583
          WEB_SITE=https://dracut.wiki.kernel.org/index.php/Main_Page
           ENTERED=20120715
           UPDATED=20250307


### PR DESCRIPTION
They seem to have reissued their tar files, and also changed
the directory they unpack into from "dracut-ng-$VERSION" to
just "dracut-$VERSION".
