### PR TITLE
XML-Parser: Bump to 2.59. The recent perl bump now requries File-Shar…

### DIFF
--- a/perl/XML-Parser/DEPENDS
+++ b/perl/XML-Parser/DEPENDS
@@ -1,3 +1,4 @@
 depends perl
 depends Devel-CheckLib
+depends File-ShareDir-Install
 depends expat

--- a/perl/XML-Parser/DETAILS
+++ b/perl/XML-Parser/DETAILS
@@ -1,11 +1,11 @@
           MODULE=XML-Parser
-         VERSION=2.47
+         VERSION=2.59
           SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=https://cpan.metacpan.org/authors/id/T/TO/TODDR/
-      SOURCE_VFY=sha256:ad4aae643ec784f489b956abe952432871a622d4e2b5c619e8855accbfc4d1d8
+      SOURCE_VFY=sha256:a358fd7c49f5e27717a644a9102bd21dc7fc25a415983279c59b1580e2b62a58
         WEB_SITE=https://metacpan.org/pod/XML::Parser
          ENTERED=20030529
-         UPDATED=20240206
+         UPDATED=20260807
            SHORT="PERL module for parsing XML documents"
 cat << EOF
 PERL modules for parsing XML documents

--- a/perl/XML-Parser/DETAILS
+++ b/perl/XML-Parser/DETAILS
@@ -7,6 +7,7 @@
          ENTERED=20030529
          UPDATED=20260807
            SHORT="PERL module for parsing XML documents"
+
 cat << EOF
 PERL modules for parsing XML documents
 EOF

--- a/perl/XML-Parser/PRE_BUILD
+++ b/perl/XML-Parser/PRE_BUILD
@@ -1,4 +1,0 @@
-default_pre_build &&
-
-# The bundled CheckLib.pm will break detection of expat
-rm inc/Devel/CheckLib.pm || exit


### PR DESCRIPTION
…eDir-Install

depends. Remove PRE_BUILD, expat compiles fine here.