### PR TITLE
gettext: version bumped to 1.0

### DIFF
--- a/libs/gettext/DETAILS
+++ b/libs/gettext/DETAILS
@@ -1,12 +1,12 @@
           MODULE=gettext
-         VERSION=0.26
+         VERSION=1.0
           SOURCE=$MODULE-$VERSION.tar.xz
    SOURCE_URL[0]=$GNU_URL/$MODULE
    SOURCE_URL[1]=ftp://ftp.gnu.org/pub/gnu/$MODULE
-      SOURCE_VFY=sha256:d1fb86e260cfe7da6031f94d2e44c0da55903dbae0a2fa0fae78c91ae1b56f00
+      SOURCE_VFY=sha256:71132a3fb71e68245b8f2ac4e9e97137d3e5c02f415636eb508ae607bc01add7
         WEB_SITE=https://www.gnu.org/software/gettext
          ENTERED=20010922
-         UPDATED=20250902
+         UPDATED=20260810
            SHORT="The GNU internationalisation library"
 
 cat << EOF


### PR DESCRIPTION
This version works with glibc 2.41 (current) and 2.44 (future)