### PR TITLE
Util-linux: Version bump to 2.42.2 and move everything into /usr

### DIFF
--- a/utils/util-linux/BUILD
+++ b/utils/util-linux/BUILD
@@ -1,4 +1,5 @@
 export PYTHONDONTWRITEBYTECODE=1 &&
+export DESTDIR=$(pwd)/_pkg &&
 
 #Unknown group 'rfkill', lets make one
 add_priv_group rfkill &&
@@ -15,27 +16,28 @@ OPTS+=" --enable-agetty     \
         --enable-write      \
         --disable-kill      \
         --disable-static    \
+        --bindir=/usr/bin   \
+        --libdir=/usr/lib   \
+        --sbindir=/usr/sbin \
         --enable-fs-paths-extra=/usr/bin:/usr/sbin"
 
 default_config &&
 make ${MAKES:+-j${MAKES}} &&
-mkdir _pkg &&
-make install DESTDIR=$(cd _pkg && pwd) &&
-mv _pkg/sbin/sulogin _pkg/usr/sbin &&
-mv _pkg/bin/lsblk _pkg/usr/bin &&
-chmod 700 _pkg/usr/bin/wall &&
-chmod 4711 _pkg/usr/bin/{newgrp,ch{sh,fn}} &&
+mkdir ${DESTDIR} &&
+make install DESTDIR=${DESTDIR} &&
+chmod 700 ${DESTDIR}/usr/bin/wall &&
+chmod 4711 ${DESTDIR}/usr/bin/{newgrp,ch{sh,fn}} &&
+ln -sf last ${DESTDIR}/usr/bin/lastb &&
+install -g0 -o0 -m755 $SCRIPT_DIRECTORY/make-issue ${DESTDIR}/usr/bin/make-issue &&
+install -Dm644 $SCRIPT_DIRECTORY/60-rfkill.rules ${DESTDIR}/usr/lib/udev/rules.d/60-rfkill.rules &&
+
 if module_installed systemd; then
-  sedit '/ListenStream/ aRuntimeDirectory=uuidd' _pkg/usr/lib/systemd/system/uuidd.socket
+  sedit '/ListenStream/ aRuntimeDirectory=uuidd' ${DESTDIR}/usr/lib/systemd/system/uuidd.socket
 fi &&
 
-cd _pkg &&
+cd ${DESTDIR} &&
 prepare_install &&
-find . -depth -print0 | cpio -0pdmuv / &&
-
-install -g0 -o0 -m755 $SCRIPT_DIRECTORY/make-issue /usr/bin/make-issue &&
-install -Dm644 $SCRIPT_DIRECTORY/60-rfkill.rules /usr/lib/udev/rules.d/60-rfkill.rules &&
-ln -sf /usr/bin/last /usr/bin/lastb &&
+cp -arv * / &&
 
 #/usr/lib/tmpfiles.d/uuidd-tmpfiles.conf:6: Failed to resolve user 'uuidd': No such process
 add_priv_group uuidd &&

--- a/utils/util-linux/DETAILS
+++ b/utils/util-linux/DETAILS
@@ -1,11 +1,11 @@
     MODULE=util-linux
-   VERSION=2.42.1
+   VERSION=2.42.2
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=$KERNEL_URL/pub/linux/utils/$MODULE/v${VERSION::4}
-SOURCE_VFY=sha256:82e9158eb12a9b0b569d84e1687fed9dd18fe89ccd8ef5ac3427218a7c0d7f7f
+SOURCE_VFY=sha256:03a05d3adf9602ef128f2da05b84b3205ce60c351e5737c0370f74000679ce8a
   WEB_SITE=https://github.com/util-linux/util-linux
    ENTERED=20010922
-   UPDATED=20260609
+   UPDATED=20260823
      SHORT="Essential utilities for any Linux box"
 
 cat << EOF


### PR DESCRIPTION
There's a similar one for Linux-PAM needed I guess, and then another for systemd, to move all the PAM modules into /usr/lib/security.