### PR TITLE
shadow: bump to 4.20.2

### DIFF
--- a/security/shadow/BUILD
+++ b/security/shadow/BUILD
@@ -46,8 +46,8 @@ make DESTDIR=$SOURCE_DIRECTORY/__shadowdest/ -C man install &&
 # remove the installed chfn, chsh, login, nologin, su, vigr and vipw apps
 # util-linux install these apps in Lunar
 #cp $SOURCE_DIRECTORY/__shadowdest/usr/bin/login /tmp/ &&
-rm $SOURCE_DIRECTORY/__shadowdest/usr/bin/{login,chfn,chsh,nologin} &&
-rm $SOURCE_DIRECTORY/__shadowdest/usr/sbin/{vigr,vipw,logoutd} &&
+rm -f $SOURCE_DIRECTORY/__shadowdest/usr/bin/{login,chfn,chsh,nologin} &&
+rm -f $SOURCE_DIRECTORY/__shadowdest/usr/sbin/{vigr,vipw,logoutd} &&
 mv $SOURCE_DIRECTORY/__shadowdest/usr/bin/{newgrp,sg} &&
 mv -f $SOURCE_DIRECTORY/__shadowdest/usr/{sbin/*,bin/} &&
 rm -rf $SOURCE_DIRECTORY/__shadowdest/usr/sbin &&

--- a/security/shadow/BUILD
+++ b/security/shadow/BUILD
@@ -14,6 +14,14 @@ set_login_opts() {
 # Keep shadow from installing it's own pam.d files
 sedit '/^SUBDIRS/ n; s/etc//' Makefile.in Makefile.am &&
 
+# work around a chicken-and-egg problem which should only
+# happen when building an iso
+
+if ! lvu installed systemd > /dev/null
+then
+  OPTS+=' --disable-logind '
+fi &&
+
 ./configure --prefix=/usr \
             --bindir=/usr/bin \
             --sbindir=/usr/bin \

--- a/security/shadow/DETAILS
+++ b/security/shadow/DETAILS
@@ -1,12 +1,12 @@
     MODULE=shadow
-   VERSION=4.19.4
+   VERSION=4.20.2
     SOURCE=$MODULE-$VERSION.tar.xz
 SOURCE_URL=https://github.com/shadow-maint/shadow/releases/download/$VERSION/
-SOURCE_VFY=sha256:ce57a313e315a0a7cb04a8f50cc20753e994e487bbe9b78a2a824ca75cb486c0
+SOURCE_VFY=sha256:b89f432b75ae55a2d852b446d0365484795fdf533ab97d550e325fa15594a224
   WEB_SITE=http://packages.qa.debian.org/s/shadow.html
 MAINTAINER=ratler@lunar-linux.org
    ENTERED=20010922
-   UPDATED=20260312
+   UPDATED=20260825
      SHORT="Contains the shadow password file utilities"
 PSAFE=no
 


### PR DESCRIPTION
changes:
- **shadow: Build without logind support if systemd is absent**
- **shadow: Version bumped to 4.20.2.**
